### PR TITLE
Reading hadoopConfiguration directly from Spark.

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/runBenchmarks.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/runBenchmarks.scala
@@ -143,7 +143,7 @@ abstract class Dataset(
 
   def checkData(): Unit = {
     tablesForTest.foreach { table =>
-      val fs = FileSystem.get(new java.net.URI(table.outputDir), new Configuration())
+      val fs = FileSystem.get(new java.net.URI(table.outputDir), sparkContext.hadoopConfiguration)
       val exists = fs.exists(new Path(table.outputDir))
       val wasSuccessful = fs.exists(new Path(s"${table.outputDir}/_SUCCESS"))
 


### PR DESCRIPTION
Read hadoopConfiguration from SparkContext instead of creating a new Configuration directly from Hadoop config files.
This allow us to use hadoop parameters inserted or modified in one of Spark's config files. (e.g.: Swift credentials).