### PR TITLE
Allow saving benchmark queries results as parquet files

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/bigdata/Queries.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/bigdata/Queries.scala
@@ -16,7 +16,7 @@
 
 package com.databricks.spark.sql.perf.bigdata
 
-import com.databricks.spark.sql.perf.Query
+import com.databricks.spark.sql.perf.{ForeachResults, Query}
 
 object Queries {
   val queries1to3 = Seq(
@@ -32,7 +32,7 @@ object Queries {
         |  pageRank > 1000
         """.stripMargin,
       description = "",
-      collectResults = false),
+      executionMode = ForeachResults),
 
     Query(
       name = "q1B",
@@ -46,7 +46,7 @@ object Queries {
         |  pageRank > 100
         """.stripMargin,
       description = "",
-      collectResults = false),
+      executionMode = ForeachResults),
 
     Query(
       name = "q1C",
@@ -60,7 +60,7 @@ object Queries {
         |  pageRank > 10
         """.stripMargin,
       description = "",
-      collectResults = false),
+      executionMode = ForeachResults),
 
     Query(
       name = "q2A",
@@ -74,7 +74,7 @@ object Queries {
         |  SUBSTR(sourceIP, 1, 8)
         """.stripMargin,
       description = "",
-      collectResults = false),
+      executionMode = ForeachResults),
 
     Query(
       name = "q2B",
@@ -88,7 +88,7 @@ object Queries {
         |  SUBSTR(sourceIP, 1, 10)
         """.stripMargin,
       description = "",
-      collectResults = false),
+      executionMode = ForeachResults),
 
     Query(
       name = "q2C",
@@ -102,7 +102,7 @@ object Queries {
         |  SUBSTR(sourceIP, 1, 12)
         """.stripMargin,
       description = "",
-      collectResults = false),
+      executionMode = ForeachResults),
 
     Query(
       name = "q3A",
@@ -121,7 +121,7 @@ object Queries {
         |ORDER BY totalRevenue DESC LIMIT 1
         """.stripMargin,
       description = "",
-      collectResults = false),
+      executionMode = ForeachResults),
 
     Query(
       name = "q3B",
@@ -140,7 +140,7 @@ object Queries {
         |ORDER BY totalRevenue DESC LIMIT 1
         """.stripMargin,
       description = "",
-      collectResults = false),
+      executionMode = ForeachResults),
 
     Query(
       name = "q3C",
@@ -158,6 +158,6 @@ object Queries {
         |ORDER BY totalRevenue DESC LIMIT 1
         """.stripMargin,
       description = "",
-      collectResults = false)
+      executionMode = ForeachResults)
   )
 }

--- a/src/main/scala/com/databricks/spark/sql/perf/bigdata/Queries.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/bigdata/Queries.scala
@@ -16,7 +16,8 @@
 
 package com.databricks.spark.sql.perf.bigdata
 
-import com.databricks.spark.sql.perf.{ForeachResults, Query}
+import com.databricks.spark.sql.perf.ExecutionMode.ForeachResults
+import com.databricks.spark.sql.perf.Query
 
 object Queries {
   val queries1to3 = Seq(

--- a/src/main/scala/com/databricks/spark/sql/perf/query.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/query.scala
@@ -36,7 +36,7 @@ case class QueryForTest(
     (endTime - startTime).toDouble / 1000000
   }
 
-  def benchmark(description: String = "") = {
+  def benchmark(description: String = "", queryOutputLocation: Option[String]) = {
     try {
       sparkContext.setJobDescription(s"Query: ${query.name}, $description")
       val dataFrame = sqlContext.sql(query.sqlText)
@@ -76,6 +76,8 @@ case class QueryForTest(
           tableIdentifier.last
         }
       }
+
+      queryOutputLocation.foreach(dir => dataFrame.saveAsParquetFile(s"$dir/$name.parquet"))
 
       BenchmarkResult(
         name = query.name,

--- a/src/main/scala/com/databricks/spark/sql/perf/query.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/query.scala
@@ -90,7 +90,7 @@ case class QueryForTest(
           tableIdentifier.last
         }
       }
-      
+
       BenchmarkResult(
         name = query.name,
         joinTypes = joinTypes,

--- a/src/main/scala/com/databricks/spark/sql/perf/query.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/query.scala
@@ -78,9 +78,7 @@ case class QueryForTest(
         query.executionMode match {
           case CollectResults => dataFrame.rdd.collect()
           case ForeachResults => dataFrame.rdd.foreach { row => Unit }
-          case WriteParquet(location) => {
-            dataFrame.rdd.collect()
-            dataFrame.saveAsParquetFile(s"$location/$name.parquet")
+          case WriteParquet(location) => dataFrame.saveAsParquetFile(s"$location/$name.parquet")
           }
         }
       }

--- a/src/main/scala/com/databricks/spark/sql/perf/query.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/query.scala
@@ -50,7 +50,7 @@ case class QueryForTest(
     (endTime - startTime).toDouble / 1000000
   }
 
-  def benchmark(description: String = "", queryOutputLocation: Option[String]) = {
+  def benchmark(description: String = "") = {
     try {
       sparkContext.setJobDescription(s"Query: ${query.name}, $description")
       val dataFrame = sqlContext.sql(query.sqlText)
@@ -77,7 +77,7 @@ case class QueryForTest(
       val executionTime = query.executionMode match {
         case CollectResults => benchmarkMs { dataFrame.rdd.collect() }
         case ForeachResults => benchmarkMs { dataFrame.rdd.foreach { row => Unit } }
-        case WriteParquet(location) => benchmarkMs { dataFrame.saveAsParquetFile(s"$location/${query.name}.parquet") }
+        case WriteParquet(location) => benchmarkMs { dataFrame.saveAsParquetFile(s"$location/$name.parquet") }
       }
 
       val joinTypes = dataFrame.queryExecution.executedPlan.collect {
@@ -90,9 +90,7 @@ case class QueryForTest(
           tableIdentifier.last
         }
       }
-
-      queryOutputLocation.foreach(dir => dataFrame.saveAsParquetFile(s"$dir/$name.parquet"))
-
+      
       BenchmarkResult(
         name = query.name,
         joinTypes = joinTypes,

--- a/src/main/scala/com/databricks/spark/sql/perf/runBenchmarks.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/runBenchmarks.scala
@@ -196,7 +196,6 @@ abstract class Dataset(
   def runExperiment(
       queries: Seq[Query],
       resultsLocation: String,
-      queryOutputLocation: Option[String] = None,
       includeBreakdown: Boolean = false,
       iterations: Int = 3,
       variations: Seq[Variation[_]] = Seq(Variation("StandardRun", Seq("")) { _ => {} }),
@@ -239,7 +238,7 @@ abstract class Dataset(
                 currentMessages += s"Running query ${q.name} $setup"
 
                 currentQuery = q.name
-                val singleResult = try q.benchmark(setup, queryOutputLocation) :: Nil catch {
+                val singleResult = try q.benchmark(setup) :: Nil catch {
                   case e: Exception =>
                     currentMessages += s"Failed to run query ${q.name}: $e"
                     Nil

--- a/src/main/scala/com/databricks/spark/sql/perf/runBenchmarks.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/runBenchmarks.scala
@@ -183,6 +183,7 @@ abstract class Dataset(
    * Starts an experiment run with a given set of queries.
    * @param queries Queries to be executed.
    * @param resultsLocation The location of performance results.
+   * @param queryOutputLocation If defined, location where queries results should be saved as parquet files
    * @param includeBreakdown If it is true, breakdown results of a query will be recorded.
    *                         Setting it to true may significantly increase the time used to
    *                         execute a query.
@@ -195,6 +196,7 @@ abstract class Dataset(
   def runExperiment(
       queries: Seq[Query],
       resultsLocation: String,
+      queryOutputLocation: Option[String] = None,
       includeBreakdown: Boolean = false,
       iterations: Int = 3,
       variations: Seq[Variation[_]] = Seq(Variation("StandardRun", Seq("")) { _ => {} }),
@@ -237,7 +239,7 @@ abstract class Dataset(
                 currentMessages += s"Running query ${q.name} $setup"
 
                 currentQuery = q.name
-                val singleResult = try q.benchmark(setup) :: Nil catch {
+                val singleResult = try q.benchmark(setup, queryOutputLocation) :: Nil catch {
                   case e: Exception =>
                     currentMessages += s"Failed to run query ${q.name}: $e"
                     Nil

--- a/src/main/scala/com/databricks/spark/sql/perf/runBenchmarks.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/runBenchmarks.scala
@@ -183,7 +183,6 @@ abstract class Dataset(
    * Starts an experiment run with a given set of queries.
    * @param queries Queries to be executed.
    * @param resultsLocation The location of performance results.
-   * @param queryOutputLocation If defined, location where queries results should be saved as parquet files
    * @param includeBreakdown If it is true, breakdown results of a query will be recorded.
    *                         Setting it to true may significantly increase the time used to
    *                         execute a query.

--- a/src/main/scala/com/databricks/spark/sql/perf/table.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/table.scala
@@ -16,21 +16,9 @@
 
 package com.databricks.spark.sql.perf
 
-import java.text.SimpleDateFormat
-import java.util.Date
-
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{Path, FileSystem}
-import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
-import org.apache.hadoop.mapreduce.{OutputCommitter, TaskAttemptContext, RecordWriter, Job}
-import org.apache.spark.SerializableWritable
-import org.apache.spark.sql.{SQLContext, Column}
-import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.hive.HiveMetastoreTypes
 import org.apache.spark.sql.types._
-import parquet.hadoop.ParquetOutputFormat
-import parquet.hadoop.util.ContextUtil
 
 abstract class TableType
 case object UnpartitionedTable extends TableType
@@ -47,7 +35,7 @@ abstract class TableForTest(
 
   val name = table.name
 
-  val outputDir = s"$baseDir/parquet/${name}"
+  val outputDir = s"$baseDir/${name}"
 
   def fromCatalog = sqlContext.table(name)
 

--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/queries/ImpalaKitQueries.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/queries/ImpalaKitQueries.scala
@@ -16,7 +16,7 @@
 
 package com.databricks.spark.sql.perf.tpcds.queries
 
-import com.databricks.spark.sql.perf.Query
+import com.databricks.spark.sql.perf.{CollectResults, Query}
 
 object ImpalaKitQueries {
   // Queries are from
@@ -1024,7 +1024,7 @@ object ImpalaKitQueries {
                  |from store_sales
                """.stripMargin)
   ).map {
-    case (name, sqlText) => Query(name, sqlText, description = "", collectResults = true)
+    case (name, sqlText) => Query(name, sqlText, description = "", executionMode = CollectResults)
   }
   val queriesMap = queries.map(q => q.name -> q).toMap
 
@@ -1463,7 +1463,7 @@ object ImpalaKitQueries {
         |from store_sales
       """.stripMargin)
   ).map {
-    case (name, sqlText) => Query(name, sqlText, description = "original query", collectResults = true)
+    case (name, sqlText) => Query(name, sqlText, description = "original query", executionMode = CollectResults)
   }
 
   val interactiveQueries =

--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/queries/ImpalaKitQueries.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/queries/ImpalaKitQueries.scala
@@ -16,7 +16,8 @@
 
 package com.databricks.spark.sql.perf.tpcds.queries
 
-import com.databricks.spark.sql.perf.{CollectResults, Query}
+import com.databricks.spark.sql.perf.ExecutionMode.CollectResults
+import com.databricks.spark.sql.perf.Query
 
 object ImpalaKitQueries {
   // Queries are from
@@ -1462,8 +1463,8 @@ object ImpalaKitQueries {
         |  max(ss_promo_sk) as max_ss_promo_sk
         |from store_sales
       """.stripMargin)
-  ).map {
-    case (name, sqlText) => Query(name, sqlText, description = "original query", executionMode = CollectResults)
+  ).map { case (name, sqlText) =>
+    Query(name, sqlText, description = "original query", executionMode = CollectResults)
   }
 
   val interactiveQueries =

--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/queries/SimpleQueries.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/queries/SimpleQueries.scala
@@ -16,7 +16,7 @@
 
 package com.databricks.spark.sql.perf.tpcds.queries
 
-import com.databricks.spark.sql.perf.Query
+import com.databricks.spark.sql.perf.{ForeachResults, Query}
 
 object SimpleQueries {
    val q7Derived = Seq(
@@ -137,6 +137,6 @@ object SimpleQueries {
               |-- end query 1 in stream 0 using template query7.tpl
             """.stripMargin)
    ).map {
-     case (name, sqlText) => Query(name = name, sqlText = sqlText, description = "", collectResults = false)
+     case (name, sqlText) => Query(name = name, sqlText = sqlText, description = "", executionMode = ForeachResults)
    }
 }

--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/queries/SimpleQueries.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/queries/SimpleQueries.scala
@@ -16,7 +16,8 @@
 
 package com.databricks.spark.sql.perf.tpcds.queries
 
-import com.databricks.spark.sql.perf.{ForeachResults, Query}
+import com.databricks.spark.sql.perf.ExecutionMode.ForeachResults
+import com.databricks.spark.sql.perf.Query
 
 object SimpleQueries {
    val q7Derived = Seq(
@@ -136,7 +137,7 @@ object SimpleQueries {
               |limit 100
               |-- end query 1 in stream 0 using template query7.tpl
             """.stripMargin)
-   ).map {
-     case (name, sqlText) => Query(name = name, sqlText = sqlText, description = "", executionMode = ForeachResults)
+   ).map { case (name, sqlText) =>
+     Query(name = name, sqlText = sqlText, description = "", executionMode = ForeachResults)
    }
 }


### PR DESCRIPTION
* Add an optional parameter while running the benchmark to specify a directory where the queries results should be saved as parquet files (example use case: make sure the queries results are the same across different benchmark run)
* Remove the hardcoded directory structure baseDir/parquet/ => baseDir/

