### PR TITLE
Job does not submit in TPCDS partitioned table data generate

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/Tables.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/Tables.scala
@@ -108,7 +108,7 @@ case class TPCDSTableForTest(
         val job = new Job(sqlContext.sparkContext.hadoopConfiguration)
 
         val writeSupport =
-          if (schema.fields.map(_.dataType).forall(_.isPrimitive)) {
+          if (schema.fields.map(_.dataType).forall(ParquetTypesConverter.isPrimitiveType)) {
             classOf[org.apache.spark.sql.parquet.MutableRowWriteSupport]
           } else {
             classOf[org.apache.spark.sql.parquet.RowWriteSupport]

--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/Tables.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/Tables.scala
@@ -135,6 +135,11 @@ case class TPCDSTableForTest(
           var hadoopContext: TaskAttemptContext = null
           var committer: OutputCommitter = null
 
+          val job = new Job(conf.value)
+          val keyType = classOf[Void]
+          job.setOutputKeyClass(keyType)
+          job.setOutputValueClass(classOf[Row])
+
           var rowCount = 0
           var partition = 0
 
@@ -149,6 +154,7 @@ case class TPCDSTableForTest(
               if (writer != null) {
                 writer.close(hadoopContext)
                 committer.commitTask(hadoopContext)
+                committer.commitJob(job)
               }
               writer = null
             }
@@ -160,12 +166,9 @@ case class TPCDSTableForTest(
               if (writer != null) {
                 writer.close(hadoopContext)
                 committer.commitTask(hadoopContext)
+                committer.commitJob(job)
               }
 
-              val job = new Job(conf.value)
-              val keyType = classOf[Void]
-              job.setOutputKeyClass(keyType)
-              job.setOutputValueClass(classOf[Row])
               NewFileOutputFormat.setOutputPath(
                 job,
                 new Path(s"$outputDir/$partitioningColumn=${currentPartition(0)}"))
@@ -191,6 +194,7 @@ case class TPCDSTableForTest(
           if (writer != null) {
             writer.close(hadoopContext)
             committer.commitTask(hadoopContext)
+            committer.commitJob(job)
           }
         }
         val fs = FileSystem.get(new java.net.URI(outputDir), new Configuration())


### PR DESCRIPTION
Job does not submit in TPCDS partitioned table data generate
The table "store_sales" data result path is
/tmp/spark_perf/scaleFactor=1/useDecimal=true/store_sales/ss_sold_date_sk=2452822/_temporary/0/task_201507241546_0000_r_000000/part-r-00000.parquet

in spark1.3.1 the "_temporary" path is ok. but in spark1.4+ "_temporary" path is filtered.so the exception when query:
java.lang.AssertionError: assertion failed: No schema defined, and no Parquet data file or summary file found under /tmp/spark_perf/scaleFactor=1/useDecimal=true/store_sales.

while the job commit the partitioned data path is
/tmp/spark_perf/scaleFactor=1/useDecimal=true/store_sales/ss_sold_date_sk=2452822/part-r-00000.parquet

the data read in spark1.3+ is ok.