### PR TITLE
Child tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ This is a performance testing framework for [Spark SQL](https://spark.apache.org
 ## How to use it
 The rest of document will use TPC-DS benchmark as an example. We will add contents to explain how to use other benchmarks add the support of a new benchmark dataset in future.
 
+### Prereqs
+This project uses the dsdgen tool to generate the tables. There is a
+[fork](https://github.com/nongli/tpcds-kit) of this tool to support
+streaming table generation. i.e. having the tool support writing to stdout for all tables.
+
+This needs to be built and installed on all the workers.
+
 ### Setup a benchmark
 Before running any query, a dataset needs to be setup by creating a `Benchmark` object.   
 


### PR DESCRIPTION
In some of the tpcds tables, there is a parent/child relationship. This means that
the child table cannot be generated independently and is output (optionally) as part
of generating the parent table. This benchmark requires the output being written to
stdout. When the tpcds generator runs with stdout as the output, it cannot support
child tables.

The dsdgen tool has been updated to support this and can optionally output the data
with the table prefix. For example, in this mode the output is:

store_sales|<row>
store_sales|<row>
store_returns|<row>
store_sales|<row>

The rows are interleaved but can be filtered for. This patch adds the filtering.