### PR TITLE
Introduce small integration point with Spark perf

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
@@ -392,8 +392,13 @@ abstract class Benchmark(
 
     // Benchmark run by calculating the sum of the hash value of all rows. This is used to check
     // query results.
-    case object HashResults extends ExecutionMode  {
+    case object HashResults extends ExecutionMode {
       override def toString: String = "hash"
+    }
+
+    // Results from Spark perf
+    case object SparkPerfResults extends ExecutionMode {
+      override def toString: String = "sparkPerf"
     }
   }
 

--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -42,7 +42,7 @@ case class ExperimentRun(
 case class BenchmarkConfiguration(
     sparkVersion: String = org.apache.spark.SPARK_VERSION,
     sqlConf: Map[String, String],
-    sparkConf: Map[String,String],
+    sparkConf: Map[String, String],
     defaultParallelism: Int)
 
 /**


### PR DESCRIPTION
This allows us to report Spark perf results in the same format as SQL benchmark results. @marmbrus 