### PR TITLE
Increase integration surface area with Spark perf

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -49,6 +49,7 @@ case class BenchmarkConfiguration(
  * The result of a query.
  * @param name The name of the query.
  * @param mode The ExecutionMode of this run.
+ * @param parameters Additional parameters that describe this query.
  * @param joinTypes The type of join operations in the query.
  * @param tables The tables involved in the query.
  * @param parsingTime The time used to parse the query.
@@ -64,6 +65,7 @@ case class BenchmarkConfiguration(
 case class BenchmarkResult(
     name: String,
     mode: String,
+    parameters: Map[String, String] = Map.empty[String, String],
     joinTypes: Seq[String] = Nil,
     tables: Seq[String] = Nil,
     parsingTime: Option[Double] = None,


### PR DESCRIPTION
The changes in this PR are centered around making `Benchmark#runExperiment` accept things other than `Query`s. In particular, in spark-perf we don't always have a DataFrame or an RDD to work with and may want to run arbitrary code (e.g. ALS.train). This PR makes it possible to use the same code in `Benchmark` to do this.

I tested this on dogfood and it works well there.