### PR TITLE
Make ExecutionMode.HashResults handle null value

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
@@ -597,7 +597,7 @@ abstract class Benchmark(
         // to scala.
         // The executionTime for the entire query includes the time of type conversion
         // from catalyst to scala.
-        var result: Option[java.lang.Long] = None
+        var result: Option[Long] = None
         val executionTime = measureTimeMs {
           executionMode match {
             case ExecutionMode.CollectResults => dataFrame.rdd.collect()
@@ -613,7 +613,7 @@ abstract class Benchmark(
                   .groupBy()
                   .sum("hashValue")
                   .head()
-              val sumOfHash = if (row.isNullAt(0)) null else new java.lang.Long(row.getLong(0))
+              val sumOfHash = if (row.isNullAt(0)) 0L else row.getLong(0)
               result = Some(sumOfHash)
           }
         }

--- a/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
@@ -597,7 +597,7 @@ abstract class Benchmark(
         // to scala.
         // The executionTime for the entire query includes the time of type conversion
         // from catalyst to scala.
-        var result: Option[Long] = None
+        var result: Option[java.lang.Long] = None
         val executionTime = measureTimeMs {
           executionMode match {
             case ExecutionMode.CollectResults => dataFrame.rdd.collect()
@@ -613,7 +613,7 @@ abstract class Benchmark(
                   .groupBy()
                   .sum("hashValue")
                   .head()
-              val sumOfHash = if (row.isNullAt(0)) 0L else row.getLong(0)
+              val sumOfHash = if (row.isNullAt(0)) null else new java.lang.Long(row.getLong(0))
               result = Some(sumOfHash)
           }
         }

--- a/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
@@ -613,8 +613,7 @@ abstract class Benchmark(
                   .groupBy()
                   .sum("hashValue")
                   .head()
-              val sumOfHash = if (row.isNullAt(0)) 0L else row.getLong(0)
-              result = Some(sumOfHash)
+              result = if (row.isNullAt(0)) None else Some(row.getLong(0))
           }
         }
 

--- a/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Benchmark.scala
@@ -607,14 +607,14 @@ abstract class Benchmark(
             case ExecutionMode.HashResults =>
               val columnStr = dataFrame.schema.map(_.name).mkString(",")
               // SELECT SUM(HASH(col1, col2, ...)) FROM (benchmark query)
-              val ret =
+              val row =
                 dataFrame
                   .selectExpr(s"hash($columnStr) as hashValue")
                   .groupBy()
                   .sum("hashValue")
                   .head()
-                  .getLong(0)
-              result = Some(ret)
+              val sumOfHash = if (row.isNullAt(0)) 0L else row.getLong(0)
+              result = Some(sumOfHash)
           }
         }
 

--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -73,7 +73,7 @@ case class BenchmarkResult(
     optimizationTime: Option[Double] = None,
     planningTime: Option[Double] = None,
     executionTime: Option[Double] = None,
-    result: Option[java.lang.Long] = None,
+    result: Option[Long] = None,
     breakDown: Seq[BreakdownResult] = Nil,
     queryExecution: Option[String] = None,
     failure: Option[Failure] = None)

--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -73,7 +73,7 @@ case class BenchmarkResult(
     optimizationTime: Option[Double] = None,
     planningTime: Option[Double] = None,
     executionTime: Option[Double] = None,
-    result: Option[Long] = None,
+    result: Option[java.lang.Long] = None,
     breakDown: Seq[BreakdownResult] = Nil,
     queryExecution: Option[String] = None,
     failure: Option[Failure] = None)


### PR DESCRIPTION
In Spark 1.6, if a value is null, `getLong` will throw an exception. Before 1.6, it will return 0. With this PR, we will check if the result is null. If it is null, null will be returned instead of 0.