### PR TITLE
Include publishing to BinTray in release process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,10 @@
 // Your sbt build file. Guides on how to write one can be found at
 // http://www.scala-sbt.org/0.13/docs/index.html
 
+name := "spark-sql-perf"
+
+organization := "com.databricks"
+
 scalaVersion := "2.10.4"
 
 sparkPackageName := "databricks/spark-sql-perf"
@@ -56,6 +60,35 @@ lazy val setupDbcRelease = ReleaseStep(
   }
 )
 
+/********************
+ * Release settings *
+ ********************/
+
+publishMavenStyle := true
+
+releaseCrossBuild := true
+
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
+
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+
+pomExtra := (
+      <url>https://github.com/databricks/spark-sql-perf</url>
+      <scm>
+        <url>git@github.com:databricks/spark-sql-perf.git</url>
+        <connection>scm:git:git@github.com:databricks/spark-sql-perf.git</connection>
+      </scm>
+      <developers>
+        <developer>
+          <id>marmbrus</id>
+          <name>Michael Armbrust</name>
+          <url>https://github.com/marmbrus</url>
+        </developer>
+      </developers>
+    )
+
+bintrayReleaseOnPublish in ThisBuild := false
+
 // Add publishing to spark packages as another step.
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
@@ -66,6 +99,7 @@ releaseProcess := Seq[ReleaseStep](
   tagRelease,
   setupDbcRelease,
   releaseStepTask(dbcUpload),
+  publishArtifacts,
   setNextVersion,
   commitNextVersion,
   pushChanges

--- a/build.sbt
+++ b/build.sbt
@@ -78,13 +78,6 @@ pomExtra := (
         <url>git@github.com:databricks/spark-sql-perf.git</url>
         <connection>scm:git:git@github.com:databricks/spark-sql-perf.git</connection>
       </scm>
-      <developers>
-        <developer>
-          <id>marmbrus</id>
-          <name>Michael Armbrust</name>
-          <url>https://github.com/marmbrus</url>
-        </developer>
-      </developers>
     )
 
 bintrayReleaseOnPublish in ThisBuild := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,7 @@ addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 
 addSbtPlugin("com.databricks" %% "sbt-databricks" % "0.1.3")
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3-SNAPSHOT"
+version in ThisBuild := "0.2.3-test"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.4-SNAPSHOT"
+version in ThisBuild := "0.2.3-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3-test"
+version in ThisBuild := "0.2.4-SNAPSHOT"


### PR DESCRIPTION
After this you should be able to use the library in the shell as follows:

```
bin/spark-shell --packages com.databricks:spark-sql-perf:0.2.3
```