### PR TITLE
Improvements to running the benchmark

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-ARGS="runMain com.databricks.spark.sql.perf.RunBenchmark $@"
+# runs spark-sql-perf from the current directory
+
+ARGS="runBenchmark $@"
 build/sbt "$ARGS"

--- a/bin/spark-perf
+++ b/bin/spark-perf
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# runs the most recent published version of spark-sql-perf, from within the spark directory
+# spark is compiled using SBT
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+VERSION=`git -C $DIR/../ tag | tail -n 1 | cut -c 2-`
+ARGS="sparkPackage com.databricks:spark-sql-perf_2.10:$VERSION com.databricks.spark.sql.perf.RunBenchmark $@"
+build/sbt "$ARGS"

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,16 @@ dbcClusters += sys.env.getOrElse("DBC_USERNAME", sys.error("Please set DBC_USERN
 
 dbcLibraryPath := s"/Users/${sys.env.getOrElse("DBC_USERNAME", sys.error("Please set DBC_USERNAME"))}/lib"
 
+val runBenchmark = inputKey[Unit]("runs a benchmark")
+
+runBenchmark := {
+  import complete.DefaultParsers._
+  val args = spaceDelimited("[args]").parsed
+  val scalaRun = (runner in run).value
+  val classpath = (fullClasspath in Compile).value
+  scalaRun.run("com.databricks.spark.sql.perf.RunBenchmark", classpath.map(_.data), args, streams.value.log)
+}
+
 import ReleaseTransformations._
 
 /** Push to the team directory instead of the user's homedir for releases. */


### PR DESCRIPTION
 - Scripts for running the benchmark either while working on spark-sql-perf (bin/run) or while working on Spark (bin/spark-perf).  The latter uses Spark's sbt build to compile spark and downloads the most recent published version of spark-sql-perf.
 - Adds a `--compare` that can be used to compare the results with a baseline run