### PR TITLE
Add job to run TPCDS and generate data.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,14 +5,14 @@ name := "spark-sql-perf"
 
 organization := "com.databricks"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
 
 sparkPackageName := "databricks/spark-sql-perf"
 
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
-sparkVersion := "2.0.0-SNAPSHOT"
+sparkVersion := "2.0.0-preview"
 
 sparkComponents ++= Seq("sql", "hive", "mllib")
 
@@ -43,7 +43,8 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 
 libraryDependencies += "org.yaml" % "snakeyaml" % "1.17"
 
-libraryDependencies += "com.typesafe" %% "scalalogging-slf4j" % "1.1.0"
+libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.3.0"
+
 
 fork := true
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("com.databricks" %% "sbt-databricks" % "0.1.3")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/src/main/scala/com/databricks/spark/sql/perf/Benchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Benchmarkable.scala
@@ -18,19 +18,21 @@ package com.databricks.spark.sql.perf
 
 import java.util.UUID
 
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.Logger
 
 import scala.concurrent.duration._
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.{SparkEnv, SparkContext}
+import org.apache.spark.{SparkContext, SparkEnv}
+import org.slf4j.LoggerFactory
 
 
 /** A trait to describe things that can be benchmarked. */
-trait Benchmarkable extends Logging {
+trait Benchmarkable extends {
   @transient protected[this] val sqlContext = SQLContext.getOrCreate(SparkContext.getOrCreate())
   @transient protected[this] val sparkContext = sqlContext.sparkContext
+
+  val logger = Logger(LoggerFactory.getLogger("MASTER_LOGGER"))
 
   val name: String
   protected val executionMode: ExecutionMode

--- a/src/main/scala/com/databricks/spark/sql/perf/RunTPCDS.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/RunTPCDS.scala
@@ -23,24 +23,20 @@ import org.apache.spark.{SparkConf, SparkContext}
 
 
 case class RunTPCDSConfig(
-                           // For table generation.
-                           generateInput: Boolean = true,
-                           dsdgenDir: String = "",
-                           scaleFactor: Int = 1,
-                           inputDir: String = "",
-                           tableFilter: String = "",
-
-                           databaseName: String = "",
-                           format: String = "parquet",
-                           partitionTables: Boolean = false,
-                           clusterByPartitionColumns: Boolean = false,
-
-                           filter: Option[String] = None,
-                           iterations: Int = 3)
-
+    generateInput: Boolean = true,
+    dsdgenDir: String = "",
+    scaleFactor: Int = 1,
+    inputDir: String = "",
+    tableFilter: String = "",
+    databaseName: String = "",
+    format: String = "parquet",
+    partitionTables: Boolean = false,
+    clusterByPartitionColumns: Boolean = false,
+    filter: Option[String] = None,
+    iterations: Int = 3)
 
 /**
-  * Runs a benchmark locally and prints the results to the screen.
+  * Runs a benchmark and prints the results to the screen.
   * Configs:
   * spark.sql.perf.results
   *

--- a/src/main/scala/com/databricks/spark/sql/perf/RunTPCDS.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/RunTPCDS.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015 Databricks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.spark.sql.perf
+
+import com.databricks.spark.sql.perf.tpcds.{TPCDS, Tables}
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.functions._
+import org.apache.spark.{SparkConf, SparkContext}
+
+
+case class RunTPCDSConfig(
+                           // For table generation.
+                           generateInput: Boolean = true,
+                           dsdgenDir: String = "",
+                           scaleFactor: Int = 1,
+                           inputDir: String = "",
+                           tableFilter: String = "",
+
+                           databaseName: String = "",
+                           format: String = "parquet",
+                           partitionTables: Boolean = false,
+                           clusterByPartitionColumns: Boolean = false,
+
+                           filter: Option[String] = None,
+                           iterations: Int = 3)
+
+
+/**
+  * Runs a benchmark locally and prints the results to the screen.
+  * Configs:
+  * spark.sql.perf.results
+  *
+  * spark.sql.perf.generate.input
+  * spark.sql.perf.dsdgen.dir
+  * spark.sql.perf.scale.factor
+  * spark.sql.perf.input.dir
+  * spark.sql.perf.table.filter
+  *
+  * spark.sql.database.name
+  * spark.sql.perf.format
+  * spark.sql.perf.partition.tables
+  * spark.sql.perf.cluster.partition.columns
+  *
+  * spark.sql.perf.filter
+  * spark.sql.perf.iterations
+  */
+object RunTPCDS {
+  def main(args: Array[String]): Unit = {
+    val conf = new SparkConf().setAppName(getClass.getName)
+
+    val sc = SparkContext.getOrCreate(conf)
+    val sqlContext = SQLContext.getOrCreate(sc)
+    import sqlContext.implicits._
+
+    val generateInput = sqlContext.getConf("spark.sql.perf.generate.input", "false").toBoolean
+    val dsdgenDir = sqlContext.getConf("spark.sql.perf.dsdgen.dir")
+    val scaleFactor = sqlContext.getConf("spark.sql.perf.scale.factor", "1").toInt
+    val inputDir = sqlContext.getConf("spark.sql.perf.input.dir")
+    val filter = sqlContext.getConf("spark.sql.perf.filter", "")
+    val iterations = sqlContext.getConf("spark.sql.perf.iterations", "3").toInt
+    val tableFilter = sqlContext.getConf("spark.sql.perf.table.filter", "")
+
+    val config = RunTPCDSConfig(
+      generateInput = generateInput,
+      dsdgenDir = dsdgenDir,
+      scaleFactor = scaleFactor,
+      tableFilter = tableFilter,
+      inputDir = inputDir,
+      filter = Some(filter),
+      iterations = iterations)
+
+    createTable(sqlContext, config)
+    run(sqlContext, config)
+  }
+
+  def createTable(sqlContext: SQLContext, config: RunTPCDSConfig): Unit = {
+    val conf = sqlContext.getAllConfs
+    val tables = new Tables(sqlContext, config.dsdgenDir, config.scaleFactor)
+    if (config.generateInput) {
+      tables.genData(
+        config.inputDir, config.format, true, config.partitionTables, true, config.clusterByPartitionColumns, true,
+        config.tableFilter)
+    }
+    if (!config.databaseName.isEmpty) {
+      tables.createExternalTables(config.inputDir, config.format, config.databaseName, true)
+    } else {
+      tables.createTemporaryTables(config.inputDir, config.format)
+    }
+  }
+
+  def run(sqlContext: SQLContext, config: RunTPCDSConfig): Unit = {
+    import sqlContext.implicits._
+
+    val benchmark = new TPCDS(sqlContext = sqlContext)
+
+    println("== All TPCDS Queries names == ")
+    benchmark.all.foreach(x => println(x.name))
+
+    val allQueries = config.filter.map { f =>
+      benchmark.all.filter(_.name matches f)
+    } getOrElse {
+      benchmark.all
+    }
+
+    println("== QUERY LIST ==")
+    allQueries.foreach(println)
+
+    val experiment = benchmark.runExperiment(
+      executionsToRun = allQueries,
+      iterations = config.iterations)
+
+    println("== STARTING EXPERIMENT ==")
+    experiment.waitForFinish(1000 * 60 * 30)
+
+    experiment.getCurrentRuns()
+      .withColumn("result", explode($"results"))
+      .select("result.*")
+      .groupBy("name")
+      .agg(
+        min($"executionTime") as 'minTimeMs,
+        max($"executionTime") as 'maxTimeMs,
+        avg($"executionTime") as 'avgTimeMs,
+        stddev($"executionTime") as 'stdDev)
+      .orderBy("name")
+      .show(1000, truncate = false)
+    println(s"""Results: sqlContext.read.json("${experiment.resultPath}")""")
+  }
+}

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
@@ -1,11 +1,11 @@
 package com.databricks.spark.sql.perf.mllib
 
-import com.typesafe.scalalogging.slf4j.Logging
-
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.ml.Transformer
-import org.apache.spark.ml.evaluation.{MulticlassClassificationEvaluator, Evaluator}
+import org.apache.spark.ml.evaluation.Evaluator
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
+import org.slf4j.LoggerFactory
 
 /**
  * The description of a benchmark for an ML algorithm. It follows a simple, standard proceduce:
@@ -19,7 +19,9 @@ import org.apache.spark.sql.functions._
  *
  * It is assumed that the implementation is going to be an object.
  */
-trait BenchmarkAlgorithm extends Logging {
+trait BenchmarkAlgorithm {
+
+  val logger = Logger(LoggerFactory.getLogger("MASTER_LOGGER"))
 
   def trainingDataSet(ctx: MLBenchContext): DataFrame
 

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLLib.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLLib.scala
@@ -1,13 +1,12 @@
 package com.databricks.spark.sql.perf.mllib
 
-import scala.language.implicitConversions
-
 import com.databricks.spark.sql.perf._
-
-import com.typesafe.scalalogging.slf4j.Logging
-
+import com.typesafe.scalalogging.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.slf4j.LoggerFactory
+
+import scala.language.implicitConversions
 
 
 class MLLib(@transient sqlContext: SQLContext)
@@ -16,7 +15,9 @@ class MLLib(@transient sqlContext: SQLContext)
   def this() = this(SQLContext.getOrCreate(SparkContext.getOrCreate()))
 }
 
-object MLLib extends Logging {
+object MLLib {
+  val logger = Logger(LoggerFactory.getLogger("MASTER_LOGGER"))
+
 
   /**
    * Runs a set of preprogrammed experiments and blocks on completion.

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLTransformerBenchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLTransformerBenchmarkable.scala
@@ -1,7 +1,6 @@
 package com.databricks.spark.sql.perf.mllib
 
 import com.databricks.spark.sql.perf._
-import com.typesafe.scalalogging.slf4j.Logging
 import org.apache.spark.sql._
 
 import scala.collection.mutable.ArrayBuffer
@@ -10,7 +9,7 @@ class MLTransformerBenchmarkable(
     params: MLParams,
     test: BenchmarkAlgorithm,
     sqlContext: SQLContext)
-  extends Benchmarkable with Serializable with Logging {
+  extends Benchmarkable with Serializable {
 
   import MLTransformerBenchmarkable._
 

--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/Tables.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/Tables.scala
@@ -209,7 +209,7 @@ class Tables(sqlContext: SQLContext, dsdgenDir: String, scaleFactor: Int) extend
     }
 
     if (!tableFilter.isEmpty) {
-      tablesToBeGenerated = tablesToBeGenerated.filter(_.name == tableFilter)
+      tablesToBeGenerated = tablesToBeGenerated.filter(_.name contains tableFilter)
       if (tablesToBeGenerated.isEmpty) {
         throw new RuntimeException("Bad table name filter: " + tableFilter)
       }


### PR DESCRIPTION
1. Update scala version to 2.11.8
2. Use 2.0.0-preview instead of 2.0.0-SNAPSHOT
3. Update scala-logging to recent versions.
4. Add sbt assembly
5. Add a job to run TPCDS directly and generate data.

** I don't know whether this is the best way to do it. I can change this to what you prefer or keep it in my local repo if you don't think this is generally useful.