### PR TITLE
Depend on non-snapshot Spark now that 2.0.0 is released

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ sparkPackageName := "databricks/spark-sql-perf"
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
-sparkVersion := "2.0.0-SNAPSHOT"
+sparkVersion := "2.0.0"
 
 sparkComponents ++= Seq("sql", "hive", "mllib")
 
@@ -29,9 +29,6 @@ initialCommands in console :=
     |val sqlContext = TestHive
     |import sqlContext.implicits._
   """.stripMargin
-
-// TODO: remove after Spark 2.0.0 is released:
-resolvers += "apache-snapshots" at "https://repository.apache.org/snapshots/"
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5"
 


### PR DESCRIPTION
Now that Spark 2.0.0 is released, we need to update the build to use a released version instead of the snapshot (which is no longer available).

Fixes #84.