### PR TITLE
Add -m for custom master, use SBT_HOME if set, Scala 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Usage: spark-sql-perf [options]
 
   -b <value> | --benchmark <value>
         the name of the benchmark to run
+  -m <value> | --master <value
+        the master url to use
   -f <value> | --filter <value>
         a filter on the name of the queries to run
   -i <value> | --iterations <value>

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "spark-sql-perf"
 
 organization := "com.databricks"
 
-scalaVersion := "2.10.6"
+scalaVersion := "2.11.8"
 
 sparkPackageName := "databricks/spark-sql-perf"
 

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -176,7 +176,7 @@ run() {
   sbt_jar=$SBT_HOME
   # if there's no jar let's download it.
   [[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
-  #  # still no jar? uh-oh.
+  # still no jar? uh-oh.
     echo "Download failed. Obtain the sbt-launch.jar manually and place it at $sbt_jar"
     exit 1
   }

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -26,6 +26,14 @@ else
     declare java_cmd=java
 fi
 
+if test -x "$SBT_HOME"; then
+  echo -e "Using $SBT_HOME as default SBT_HOME - should be the jar name!"
+  # Could be at
+  # /usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
+  # so this would be export SBT_HOME=/usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
+  sbt_jar=${SBT_HOME}
+fi
+
 echoerr () {
   echo 1>&2 "$@"
 }
@@ -40,9 +48,7 @@ acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\.version/ {print $2}' ./project/build.properties`
   URL1=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
   JAR=build/sbt-launch-${SBT_VERSION}.jar
-
   sbt_jar=$JAR
-
   if [[ ! -f "$sbt_jar" ]]; then
     # Download sbt launch jar if it hasn't been downloaded yet
     if [ ! -f "${JAR}" ]; then
@@ -166,11 +172,13 @@ process_args () {
 
 run() {
   # no jar? download it.
-  [[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
-    # still no jar? uh-oh.
-    echo "Download failed. Obtain the sbt-launch.jar manually and place it at $sbt_jar"
-    exit 1
-  }
+  # first check SBT_HOME is present so we use what's already available
+  sbt_jar=$SBT_HOME
+  #[[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
+  #  # still no jar? uh-oh.
+  #  echo "Download failed. Obtain the sbt-launch.jar manually and place it at $sbt_jar"
+  #  exit 1
+  #}
 
   # process the combined args, then reset "$@" to the residuals
   process_args "$@"

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -176,7 +176,7 @@ run() {
   sbt_jar=$SBT_HOME
   # if there's no jar let's download it.
   [[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
-  # still no jar? uh-oh.
+    # still no jar? uh-oh.
     echo "Download failed. Obtain the sbt-launch.jar manually and place it at $sbt_jar"
     exit 1
   }

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -172,13 +172,13 @@ process_args () {
 }
 
 run() {
-  # no jar? download it.
   # first check SBT_HOME is present so we use what's already available
   sbt_jar=$SBT_HOME
+  # if there's no jar let's download it.
   [[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
   #  # still no jar? uh-oh.
-     echo "Download failed. Obtain the sbt-launch.jar manually and place it at $sbt_jar"
-     exit 1
+    echo "Download failed. Obtain the sbt-launch.jar manually and place it at $sbt_jar"
+    exit 1
   }
 
   # process the combined args, then reset "$@" to the residuals

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -28,8 +28,7 @@ fi
 
 if test -x "$SBT_HOME"; then
   echo -e "Using $SBT_HOME as default SBT_HOME - should be the jar name!"
-  # Could be at
-  # /usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
+  # Could be at /usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
   # so this would be export SBT_HOME=/usr/share/sbt-launcher-packaging/bin/sbt-launch.jar
   sbt_jar=${SBT_HOME}
 fi
@@ -48,7 +47,9 @@ acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\.version/ {print $2}' ./project/build.properties`
   URL1=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
   JAR=build/sbt-launch-${SBT_VERSION}.jar
+
   sbt_jar=$JAR
+
   if [[ ! -f "$sbt_jar" ]]; then
     # Download sbt launch jar if it hasn't been downloaded yet
     if [ ! -f "${JAR}" ]; then
@@ -174,11 +175,11 @@ run() {
   # no jar? download it.
   # first check SBT_HOME is present so we use what's already available
   sbt_jar=$SBT_HOME
-  #[[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
+  [[ -f "$sbt_jar" ]] || acquire_sbt_jar "$sbt_version" || {
   #  # still no jar? uh-oh.
-  #  echo "Download failed. Obtain the sbt-launch.jar manually and place it at $sbt_jar"
-  #  exit 1
-  #}
+     echo "Download failed. Obtain the sbt-launch.jar manually and place it at $sbt_jar"
+     exit 1
+  }
 
   # process the combined args, then reset "$@" to the residuals
   process_args "$@"

--- a/src/main/scala/com/databricks/spark/sql/perf/RunBenchmark.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/RunBenchmark.scala
@@ -107,7 +107,8 @@ object RunBenchmark {
     experiment.waitForFinish(1000 * 60 * 30)
 
     sqlContext.setConf("spark.sql.shuffle.partitions", "1")
-    experiment.getCurrentRuns()
+      
+    val toShow = experiment.getCurrentRuns()
         .withColumn("result", explode($"results"))
         .select("result.*")
         .groupBy("name")
@@ -115,9 +116,13 @@ object RunBenchmark {
           min($"executionTime") as 'minTimeMs,
           max($"executionTime") as 'maxTimeMs,
           avg($"executionTime") as 'avgTimeMs,
-          stddev($"executionTime") as 'stdDev)
+          stddev($"executionTime") as 'stdDev,
+          (stddev($"executionTime") / avg($"executionTime") * 100) as 'stdDevPercent)
         .orderBy("name")
-        .show(truncate = false)
+        
+    println("Showing at most 100 query results now")
+    toShow.show(100)
+      
     println(s"""Results: sqlContext.read.json("${experiment.resultPath}")""")
 
     config.baseline.foreach { baseTimestamp =>

--- a/src/main/scala/com/databricks/spark/sql/perf/RunBenchmark.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/RunBenchmark.scala
@@ -96,7 +96,6 @@ object RunBenchmark {
     println("== QUERY LIST ==")
     allQueries.foreach(println)
 
-    // TODO run type cluster and host is the url specified?
     val experiment = benchmark.runExperiment(
       executionsToRun = allQueries,
       iterations = config.iterations,


### PR DESCRIPTION
I've added -m and --master so we can use something other than local[*], let's still keep that as the default

I was having trouble with the sbt script so modified sbt-launch-lib.bash to check for a jar at $SBT_HOME

Also as we now specify Spark version 2.0.0 in the sbt project file I've upped the Scala version to match (2.11.8)

Tested by running with -m foo, -m local[*] and --master local[2] with

bin/run --benchmark DatasetPerformance _then the master options_
