### PR TITLE
[SC-4409] Correct query 41 in TPCDS kit

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/TPCDS_1_4_Queries.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/TPCDS_1_4_Queries.scala
@@ -1663,8 +1663,8 @@ trait Tpcds_1_4_Queries extends Benchmark {
             |        (i_color = 'light' or i_color = 'cornflower') and
             |        (i_units = 'Box' or i_units = 'Pound') and
             |        (i_size = 'medium' or i_size = 'extra large')
-            |        ))
-            |        or
+            |        ))) or
+            |       (i_manufact = i1.i_manufact and
             |        ((i_category = 'Women' and 
             |        (i_color = 'midnight' or i_color = 'snow') and
             |        (i_units = 'Pallet' or i_units = 'Gross') and


### PR DESCRIPTION
This query should have a predicate of the form
```
((a=b) and P1) 
or 
((a=b) and P2)
```
It used to fail since we were previously not able to extract the common predicate `(a=b)` and rewrite as
```
(a=b) and (P1 or P2)
```
This defect was fixed with https://issues.apache.org/jira/browse/SPARK-15122
The manual rewrite currently checked in is however `(a=b) and P1 or P2` which is not the same as the original (and which spark cannot run). 
This patch restores the original version of the query.

