### PR TITLE
Rewrite Readme; make compatible with TPC-DS 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,59 +2,111 @@
 
 [![Build Status](https://travis-ci.org/databricks/spark-sql-perf.svg)](https://travis-ci.org/databricks/spark-sql-perf)
 
-This is a performance testing framework for [Spark SQL](https://spark.apache.org/sql/) in [Apache Spark](https://spark.apache.org/) 1.6+.
+This is a performance testing framework for [Spark SQL](https://spark.apache.org/sql/) in [Apache Spark](https://spark.apache.org/) 1.6+. The toolkit includes the TPC-DS benchmark and a few other sample benchmarks.
 
-**Note: This README is still under development. Please also check our source code for more information.**
+# Build
 
-# Quick Start
+Suppose the spark-sql-perf tool is located at ~/spark-sql-perf. The (non-intuitive) command to build the benchmark is:
 
 ```
-$ bin/run --help
-
-spark-sql-perf 0.2.0
-Usage: spark-sql-perf [options]
-
-  -b <value> | --benchmark <value>
-        the name of the benchmark to run
-  -f <value> | --filter <value>
-        a filter on the name of the queries to run
-  -i <value> | --iterations <value>
-        the number of iterations to run
-  --help
-        prints this usage text
-        
-$ bin/run --benchmark DatasetPerformance
+cd ~/spark-sql-perf
+bin/run --help
 ```
 
-# TPC-DS
+The first time you run the command, it may take a while because it may download and install dependencies such as sbt. Future runs should be faster.
 
-## How to use it
-The rest of document will use TPC-DS benchmark as an example. We will add contents to explain how to use other benchmarks add the support of a new benchmark dataset in future.
+# Run a Benchmark
 
-### Setup a benchmark
-Before running any query, a dataset needs to be setup by creating a `Benchmark` object. Generating
-the TPCDS data requires dsdgen built and available on the machines. We have a fork of dsdgen that
-you will need. It can be found [here](https://github.com/davies/tpcds-kit).  
+Have a look at src/main/scala/com/databricks/spark/sql/perf/DatasetPerformance.scala. It defines a class `DatasetPerformance` which derives from Benchmark. To run this particular benchmark:
+
+```
+cd ~/spark-sql-perf
+bin/run --benchmark DatasetPerformance
+```
+
+# The TPC-DS Benchmark
+
+## Build dsdgen
+
+This step builds a data generation tool that will be called by `tables.genData()` in a later step.
+Download TPC-DS Tools from http://tpc.org.
+Another option is to use Databricks' fork of dsdgen [here](https://github.com/davies/tpcds-kit).
+
+Suppose the downloaded zip file is ~/tpc_ds/127d3fa4-fac9-43f7-b1c5-6a00c2291ab9-tpc-ds-tool.zip, and the version is v2.4.0. To unzip and build:
+
+```
+cd ~/tpc_ds
+unzip 127d3fa4-fac9-43f7-b1c5-6a00c2291ab9-tpc-ds-tool.zip
+cd v2.4.0/tools
+make
+```
+
+If the build is successful, you should get an executable `dsdgen`.
+
+**Note:** It may be necessary to change `ReportErrorNoLine(..., 1)` to `ReportErrorNoLine(..., 0)` in line 492 of driver.c, to avoid a error when running `tables.genData()` at a later step with error message like "Table ... is a child; it is populated during the build of its parent (e.g., catalog_sales builds catalog returns)."
+
+**Note for Mac:** The dsdgen tool does not build on Mac. But you can easily make it build. Essentially, you should include `stdlib.h` instead of `malloc.h`, include `limits.h` instead of `values.h`, and `#define MAXINT INT_MAX`.
+
+## Build Spark
+
+You may get Spark from http://github.com/apache/spark.
+
+Suppose the spark directory is ~/spark. To build:
+
+```
+cd ~/spark
+build/mvn -DskipTests -T 8C -Dskip -Phive -Phive-thriftserver package
+```
+
+In the above command, `-T 8C` means to use 8 threads to build; `-Phive -Phive-thriftserver` means to build with Hive support.
+
+## Start a spark-shell with access to spark-sql-perf classes
+
+Supose the previous step that builds spark-sql-perf generated a folder scala-2.11 in ~/spark-sql-perf/target.
+
+```
+cd ~/spark
+bin/spark-shell --driver-class-path ~/spark-sql-perf/target/scala-2.11/classes
+```
+
+## Generate data, create tables, and create a TPCDS object
+
+Run the following commands in the spark-shell.
 
 ```
 import com.databricks.spark.sql.perf.tpcds.Tables
-// Tables in TPC-DS benchmark used by experiments.
-// dsdgenDir is the location of dsdgen tool installed in your machines.
-val tables = new Tables(sqlContext, dsdgenDir, scaleFactor)
-// Generate data.
-tables.genData(location, format, overwrite, partitionTables, useDoubleForDecimal, clusterByPartitionColumns, filterOutNullPartitionValues)
-// Create metastore tables in a specified database for your data.
-// Once tables are created, the current database will be switched to the specified database.
-tables.createExternalTables(location, format, databaseName, overwrite)
-// Or, if you want to create temporary tables
-tables.createTemporaryTables(location, format)
-// Setup TPC-DS experiment
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
+
+val sqlContext = SQLContext.getOrCreate(sc)
+
+// Create a Tables object without generating any data yet.
+// Record the locatin of dsdgen, and scale factor 1.
+val tables = new Tables(sqlContext, "~/tpc_ds/v2.4.0/tools", 1)
+
+// Call dsdgen to create .dat files (if not exists already) in ~/tpc_ds/v2.4.0/tools.
+// Then load into parquet files to be stored at "~/datafiles".
+// The five boolean parameters are:
+// - true  = overwrite
+// - false = partitionTables
+// - true  = useDoubleForDecimal
+// - false = clusterByPartitionColumns
+// - false = filterOutNullPartitionValues
+// See the source code src/main/scala/com/databricks/spark/sql/perf/tpcds/Tables.scala.
+tables.genData("~/datafiles", "parquet", true, false, true, false, false)
+
+// Generate tables using the parquet files at ~/datafiles, in a database "tpcds".
+// The last parameter means to overwrite.
+// Note that you could also create temporary tables. Again see the source code.
+tables.createExternalTables("~/datafiles", "parquet", "tpcds", true)
+
+// Create a TPCDS object.
 import com.databricks.spark.sql.perf.tpcds.TPCDS
-val tpcds = new TPCDS (sqlContext = sqlContext)
+val tpcds = new TPCDS(sqlContext = sqlContext)
 ```
 
-### Run benchmarking queries
-After setup, users can use `runExperiment` function to run benchmarking queries and record query execution time. Taking TPC-DS as an example, you can start an experiment by using
+## Run benchmarking queries
+After setup, users can use `runExperiment()` function to run benchmarking queries and record query execution time. Taking TPC-DS as an example, you can start an experiment by using
 
 ```
 val experiment = tpcds.runExperiment(tpcds.interactiveQueries)
@@ -62,13 +114,14 @@ val experiment = tpcds.runExperiment(tpcds.interactiveQueries)
 
 For every experiment run (i.e. every call of `runExperiment`), Spark SQL Perf will use the timestamp of the start time to identify this experiment. Performance results will be stored in the sub-dir named by the timestamp in the given `resultsLocation` (for example `results/1429213883272`). The performance results are stored in the JSON format.
 
-### Retrieve results
+## Retrieve results
 While the experiment is running you can use `experiment.html` to list the status.  Once the experiment is complete, the results will be saved to the table sqlPerformance in json.
 
 ```
 // Get all experiments results.
 tpcds.createResultsTable()
 sqlContext.table("sqlPerformance")
+
 // Get the result of a particular run by specifying the timestamp of that run.
 sqlContext.table("sqlPerformance").filter("timestamp = 1429132621024")
 ```


### PR DESCRIPTION
I recently tried to use the tool to conduct some TPC-DS analysis, and it was quite a journey, largely because the instructions were seriously lacking. David DeWitt suggested that I contribute back to Databricks. Srinath suggested that I create a pull request. So there you are.

In case interested, below was my journey.

1.       The first command at the perf tool’s manual https://github.com/databricks/spark-sql-perf is “bin/run --help”.
It tried to reach out to the network but our dev server was behind a firewall. I have set HTTP proxy which worked for other programs but this script complained about failing to parse http_proxy and https_proxy.
After I manually set the environmental variables, the script runs but complained it cannot get sbt. I installed sbt and added it to path. But the script was still not happy.
Resolution: I gave up dev server, and ran it on my Mac laptop.
 
2.       After I finished the “quick start” section, I was at a total loss what to do next.
The manual says dsdgen is needed. I got one from tpc.org. It did not support building on Mac but I made it build. This part was not too hard.
The next paragraph in the manual is a pseudo-code block.
Where am I supposed to type the pseudo code? What’s the relationship between the pseudo code and the “bin/run” script? What’s the relationship between the pseudo code and my Spark cluster?
Resolution: I spent a lot of time studying various documents and source code, and eventually figured out all these. In particular, I figured that I should start my spark cluster using “spark-shell” while providing it a “driver-class-path” parameter specifying the folder that was created by the “bin/run” script.
 
3.       I had no clue what to use for variables mentioned in the code block.
For instance, in
val tables = new Tables(sqlContext, dsdgenDir, scaleFactor)
What should I use for sqlContext?
In
tables.genData(location, format, overwrite, partitionTables, useDoubleForDecimal, clusterByPartitionColumns, filterOutNullPartitionValues)
What should I use for location, format, and other variables?
Resolution: I carefully studied the source code, and did a lot of trials-and-errors to figure out.
 
4.       Incompatible versions of dsdgen.
I ran the tables.genData(…) command from the code block. It generated some files, but all files included an error message “option filter or its argument unknown”.
Resolution: I figured that this was due to a version mismatch: the perf tool supports an older version of TPC-DS tool. I modified the perf tool source code to work with the newer version of dsdgen.
 
5.       Avoiding repeated calls to dsdgen.
After I made tables.genData(…) successfully call dsdgen, I saw 24 dat files generated (good!), but no data was loaded into Spark’s parquet file folder. To debug the problem I had to iteratively change something and then call tables.genData(…). In each iteration I had to wait for the same 24 dat files to be generated. That was wasteful.
Resolution: I modified the perf tool code to reuse the already generated dat files if exist.
 
6.       Wrong encoding.
Nine out of 24 dat files were loaded into the Spark tables, before an exception was thrown. The exception was java.nio.charset.MalformedInputException.
Resolution: I did some google search and realized that when opening the dat files I should use the “Cp1252” encoding. Now all 24 dat files were loaded.
 
7.       Failure to create a TPCDS object.
The next step in the pseudo code is to create a TPCDS object. It failed – in fact at this point I was sort of expecting it to fail, because all previous steps failed upon first try. The exception was missing dependencies.
Resolution: As I was no longer enthusiastic about debugging the perf tool, I decided to cut corners. I already figured how to generate query plans given a query string. I decided to just use the 104 query strings from TPCDS class, instead of generating a TPCDS object.
 
8.       Last hurdle: not all queries work.
I wrote a script that prints out the query plans for each of the 104 query strings. It successfully generated plans but only for 28 queries. Debugging revealed that the parsing of the 29th query threw an exception.
Resolution: I modified my script to surround each parsing statement with a try-catch block, to replace the exception with an error message so that the rest of the queries have a chance to be parsed. I found 99 out of 104 queries were able to be parsed. The five failed queries had an error saying inner joins are missing non-trivial join condition.
 
Note that this pull request did not address the dependency issue at step 7.