### PR TITLE
tpcds_2_4: Add alias names to subqueries in FROM clause.

### DIFF
--- a/src/main/resources/tpcds_2_4/q2.sql
+++ b/src/main/resources/tpcds_2_4/q2.sql
@@ -6,7 +6,7 @@
         FROM web_sales
         UNION ALL
        SELECT cs_sold_date_sk sold_date_sk, cs_ext_sales_price sales_price
-        FROM catalog_sales)),
+        FROM catalog_sales) x),
  wswscs AS
  (SELECT d_week_seq,
         sum(case when (d_day_name='Sunday') then sales_price else null end) sun_sales,

--- a/src/main/resources/tpcds_2_4/q23a.sql
+++ b/src/main/resources/tpcds_2_4/q23a.sql
@@ -15,7 +15,7 @@
         where ss_customer_sk = c_customer_sk
          and ss_sold_date_sk = d_date_sk
          and d_year in (2000, 2000+1, 2000+2,2000+3)
-        group by c_customer_sk)),
+        group by c_customer_sk) x),
  best_ss_customer as
  (select c_customer_sk,sum(ss_quantity*ss_sales_price) ssales
   from store_sales, customer
@@ -38,6 +38,5 @@
          and d_moy = 2
          and ws_sold_date_sk = d_date_sk
          and ws_item_sk in (select item_sk from frequent_ss_items)
-         and ws_bill_customer_sk in (select c_customer_sk from best_ss_customer)))
+         and ws_bill_customer_sk in (select c_customer_sk from best_ss_customer))) x
  limit 100
-            

--- a/src/main/resources/tpcds_2_4/q6.sql
+++ b/src/main/resources/tpcds_2_4/q6.sql
@@ -15,7 +15,7 @@ SELECT state, cnt FROM (
              (SELECT avg(j.i_current_price) FROM item j
  	            WHERE j.i_category = i.i_category)
  GROUP BY a.ca_state
-) 
+) x
 WHERE cnt >= 10
 ORDER BY cnt LIMIT 100
             


### PR DESCRIPTION
## What changes were proposed in this pull request?
    
Since SPARK-20690 and SPARK-20916 Spark requires all subqueries in FROM clause to have an alias name.
    
## How was this patch tested?
    
Tested on SF1.