### PR TITLE
Update version.sbt to 0.5.0-SNAPSHOT in spark-sql-perf

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.12-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
Update version.sbt to 0.5.0-SNAPSHOT in preparation for merging in changes incompatible with Spark 2.1 (and older) into master. 