### PR TITLE
Don't clean blocks after every run in generic Benchmarkable

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/Benchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Benchmarkable.scala
@@ -55,15 +55,8 @@ trait Benchmarkable extends Logging {
 
   protected def beforeBenchmark(): Unit = { }
 
-  private def afterBenchmark(sc: SparkContext): Unit = {
-    // Best-effort clean up of weakly referenced RDDs, shuffles, and broadcasts
+  protected def afterBenchmark(sc: SparkContext): Unit = {
     System.gc()
-    if (sparkContext.getConf.getBoolean("spark.databricks.benchmark.cleanBlocksAfter", true)) {
-      // Remove any leftover blocks that still exist
-      sc.getExecutorStorageStatus
-          .flatMap { status => status.blocks.map { case (bid, _) => bid } }
-          .foreach { bid => SparkEnv.get.blockManager.master.removeBlock(bid) }
-    }
   }
 
   private def runBenchmarkForked(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"
+version in ThisBuild := "0.5.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
Do not clean blocks after each run in the generic Benchmarkable trait.
It seems to have been there since #33, and an option `spark.databricks.benchmark.cleanBlocksAfter` to turn it off was added to it in #98, specifically to allow parallel TPCDS streams to not wipe each other's blocks. But that option is quite well hidden and obscure, and as a SparkContext config option can only be set during cluster creation, so it's not friendly to use.

Cleaning up the blocks doesn't seem necessary for the Query Benchmarkables used for TPCDS and TPCH. Remove it from there, and leave it only for MLPipelineStageBenchmarkable.