### PR TITLE
Use DECIMAL and DATE in the default TPCDS notebooks.

### DIFF
--- a/src/main/notebooks/tpcds_datagen.scala
+++ b/src/main/notebooks/tpcds_datagen.scala
@@ -22,9 +22,9 @@ val scaleFactor = "1"
 // data format.
 val format = "parquet"
 // If false, float type will be used instead of decimal.
-val useDecimal = false 
+val useDecimal = true
 // If false, string type will be used instead of date.
-val useDate = false
+val useDate = true
 // If true, rows with nulls in partition key will be thrown away.
 val filterNull = false
 // If true, partitions will be coalesced into a single file during generation.

--- a/src/main/notebooks/tpcds_run.scala
+++ b/src/main/notebooks/tpcds_run.scala
@@ -4,9 +4,20 @@
 
 // COMMAND ----------
 
+// Database to be used:
+// TPCDS Scale factor
 val scaleFactor = "1"
-val databaseName = s"tpcds_sf${scaleFactor}_nodecimal_nodate_withnulls"
-val iterations = 1 // how many times to run the whole set of queries.
+// If false, float type will be used instead of decimal.
+val useDecimal = true
+// If false, string type will be used instead of date.
+val useDate = true
+// name of database to be used.
+val databaseName = s"tpcds_sf${scaleFactor}" +
+  s"""_${if (useDecimal) "with" else "no"}decimal""" +
+  s"""_${if (useDate) "with" else "no"}date""" +
+  s"""_${if (filterNull) "no" else "with"}nulls"""
+
+val iterations = 2 // how many times to run the whole set of queries.
 
 val timeout = 60 // timeout in hours
 


### PR DESCRIPTION
A long time ago, DECIMAL was substituted by DOUBLE and DATE by STRING to workaround some problems.
There is no reason to do it anymore.