### PR TITLE
Additional method test for some ML algos

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
@@ -1,12 +1,13 @@
 package com.databricks.spark.sql.perf.mllib
 
 import com.typesafe.scalalogging.slf4j.{LazyLogging => Logging}
-
 import org.apache.spark.ml.attribute.{NominalAttribute, NumericAttribute}
 import org.apache.spark.ml.{Estimator, PipelineStage, Transformer}
 import org.apache.spark.ml.evaluation.Evaluator
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
+
+import com.databricks.spark.sql.perf.MLResult
 
 /**
  * The description of a benchmark for an ML algorithm. It follows a simple, standard proceduce:
@@ -44,6 +45,11 @@ trait BenchmarkAlgorithm extends Logging {
   def name: String = {
     this.getClass.getCanonicalName.replace("$", "")
   }
+
+  /**
+   * Test additional methods for some algorithms.
+   */
+  def testAdditionalMethods(ctx: MLBenchContext, model: Transformer): Map[String, () => _] = null
 }
 
 /**

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
@@ -7,8 +7,6 @@ import org.apache.spark.ml.evaluation.Evaluator
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 
-import com.databricks.spark.sql.perf.MLResult
-
 /**
  * The description of a benchmark for an ML algorithm. It follows a simple, standard proceduce:
  *  - generate some test and training data
@@ -48,8 +46,14 @@ trait BenchmarkAlgorithm extends Logging {
 
   /**
    * Test additional methods for some algorithms.
+   *
+   * @param transformer The transformer which includes additional methods.
+   * @return A map which key is the additional method name, and value is a function which runs
+   *         the corresponding method.
    */
-  def testAdditionalMethods(ctx: MLBenchContext, model: Transformer): Map[String, () => _] = null
+  def testAdditionalMethods(
+      ctx: MLBenchContext,
+      transformer: Transformer): Map[String, () => _] = null
 }
 
 /**

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
@@ -80,6 +80,11 @@ class MLPipelineStageBenchmarkable(
         s" s, Scored training dataset in ${scoreTrainTime.toMillis / 1000.0} s," +
         s" test dataset in ${scoreTestTime.toMillis / 1000.0} s")
 
+      test.testAdditionalMethods(param, model).map {
+        case (name: String, func: () => _) =>
+          val (additionalMethodTime, _) = measureTime { func() }
+          name -> additionalMethodTime
+      }
 
       val ml = MLResult(
         trainingTime = Some(trainingTime.toMillis),

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
@@ -80,17 +80,18 @@ class MLPipelineStageBenchmarkable(
         s" s, Scored training dataset in ${scoreTrainTime.toMillis / 1000.0} s," +
         s" test dataset in ${scoreTestTime.toMillis / 1000.0} s")
 
-      test.testAdditionalMethods(param, model).map {
-        case (name: String, func: () => _) =>
-          val (additionalMethodTime, _) = measureTime { func() }
-          name -> additionalMethodTime
+      val additionalTests = test.testAdditionalMethods(param, model).map {
+        tuple =>
+          val (additionalMethodTime, _) = measureTime { tuple._2() }
+          tuple._1 -> additionalMethodTime.toMillis.toDouble
       }
 
       val ml = MLResult(
         trainingTime = Some(trainingTime.toMillis),
         trainingMetric = Some(scoreTraining),
         testTime = Some(scoreTestTime.toMillis),
-        testMetric = Some(scoreTest / testDataCount.get))
+        testMetric = Some(scoreTest / testDataCount.get),
+        additionalTests = additionalTests)
 
       BenchmarkResult(
         name = name,

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/Word2Vec.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/Word2Vec.scala
@@ -36,8 +36,9 @@ object Word2Vec extends BenchmarkAlgorithm with TestFromTraining {
     new ml.feature.Word2Vec().setInputCol("text")
   }
 
-  override def testAdditionalMethods(ctx: MLBenchContext, model: Transformer)
-      : Map[String, () => _] = {
+  override def testAdditionalMethods(
+      ctx: MLBenchContext,
+      model: Transformer): Map[String, () => _] = {
     import ctx.params._
 
     val rng = new Random(ctx.seed())

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/Word2Vec.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/Word2Vec.scala
@@ -1,10 +1,15 @@
 package com.databricks.spark.sql.perf.mllib.feature
 
+import scala.util.Random
+
 import org.apache.spark.ml
-import org.apache.spark.ml.PipelineStage
+import org.apache.spark.ml.{PipelineStage, Transformer}
+import org.apache.spark.ml.feature.Word2VecModel
+import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, split}
 
+import com.databricks.spark.sql.perf.MLResult
 import com.databricks.spark.sql.perf.mllib.{BenchmarkAlgorithm, MLBenchContext, TestFromTraining}
 import com.databricks.spark.sql.perf.mllib.OptionImplicits._
 import com.databricks.spark.sql.perf.mllib.data.DataGenerator
@@ -29,6 +34,19 @@ object Word2Vec extends BenchmarkAlgorithm with TestFromTraining {
 
   override def getPipelineStage(ctx: MLBenchContext): PipelineStage = {
     new ml.feature.Word2Vec().setInputCol("text")
+  }
+
+  override def testAdditionalMethods(ctx: MLBenchContext, model: Transformer)
+      : Map[String, () => _] = {
+    import ctx.params._
+
+    val rng = new Random(ctx.seed())
+    val word2vecModel = model.asInstanceOf[Word2VecModel]
+    val testWord = Vectors.dense(Array.fill(word2vecModel.getVectorSize)(rng.nextGaussian()))
+
+    Map("findSynonyms" -> (() => {
+      word2vecModel.findSynonyms(testWord, numSynonymsToFind)
+    }))
   }
 
 }

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/fpm/FPGrowth.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/fpm/FPGrowth.scala
@@ -1,7 +1,8 @@
 package com.databricks.spark.sql.perf.mllib.fpm
 
 import org.apache.spark.ml
-import org.apache.spark.ml.PipelineStage
+import org.apache.spark.ml.{PipelineStage, Transformer}
+import org.apache.spark.ml.fpm.FPGrowthModel
 import org.apache.spark.sql.DataFrame
 
 import com.databricks.spark.sql.perf.mllib._
@@ -27,5 +28,14 @@ object FPGrowth extends BenchmarkAlgorithm with TestFromTraining {
   override def getPipelineStage(ctx: MLBenchContext): PipelineStage = {
     new ml.fpm.FPGrowth()
       .setItemsCol("items")
+  }
+
+  override def testAdditionalMethods(ctx: MLBenchContext, model: Transformer)
+      : Map[String, () => _] = {
+
+    val fpModel = model.asInstanceOf[FPGrowthModel]
+    Map("associationRules" -> (() => {
+      fpModel.associationRules
+    }))
   }
 }

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/fpm/FPGrowth.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/fpm/FPGrowth.scala
@@ -30,12 +30,13 @@ object FPGrowth extends BenchmarkAlgorithm with TestFromTraining {
       .setItemsCol("items")
   }
 
-  override def testAdditionalMethods(ctx: MLBenchContext, model: Transformer)
-      : Map[String, () => _] = {
+  override def testAdditionalMethods(
+      ctx: MLBenchContext,
+      model: Transformer): Map[String, () => _] = {
 
     val fpModel = model.asInstanceOf[FPGrowthModel]
     Map("associationRules" -> (() => {
-      fpModel.associationRules
+      fpModel.associationRules.count()
     }))
   }
 }

--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -131,6 +131,7 @@ class MLParams(
     val numClasses: Option[Int] = None,
     val numFeatures: Option[Int] = None,
     val numHashTables: Option[Int] = Some(1),
+    val numSynonymsToFind: Option[Int] = None,
     val numInputCols: Option[Int] = None,
     val numItems: Option[Int] = None,
     val numUsers: Option[Int] = None,
@@ -173,6 +174,7 @@ class MLParams(
       numClasses: Option[Int] = numClasses,
       numFeatures: Option[Int] = numFeatures,
       numHashTables: Option[Int] = numHashTables,
+      numSynonymsToFind: Option[Int] = numSynonymsToFind,
       numInputCols: Option[Int] = numInputCols,
       numItems: Option[Int] = numItems,
       numUsers: Option[Int] = numUsers,
@@ -188,8 +190,8 @@ class MLParams(
       elasticNetParam = elasticNetParam, family = family, featureArity = featureArity,
       itemSetSize = itemSetSize, k = k, link = link, maxIter = maxIter,
       numClasses = numClasses, numFeatures = numFeatures, numHashTables = numHashTables,
-      numInputCols = numInputCols, numItems = numItems, numUsers = numUsers,
-      optimizer = optimizer, regParam = regParam,
+      numInputCols = numInputCols, numItems = numItems, numSynonymsToFind = numSynonymsToFind,
+      numUsers = numUsers, optimizer = optimizer, regParam = regParam,
       rank = rank, smoothing = smoothing, tol = tol, vocabSize = vocabSize)
   }
 }
@@ -207,9 +209,13 @@ object MLParams {
  * @param testTime  (MLlib) Test time (for prediction on test set, or on training set if there
  *                  is no test set).
  * @param testMetric  (MLlib) Test metric, such as accuracy
+  * @param runAssociationRulesTime  (MLlib) run association rules time
+  * @param findSynonymsTime  (MLlib) word2Vec model find synonyms time
  */
 case class MLResult(
     trainingTime: Option[Double] = None,
     trainingMetric: Option[Double] = None,
     testTime: Option[Double] = None,
-    testMetric: Option[Double] = None)
+    testMetric: Option[Double] = None,
+    var runAssociationRulesTime: Option[Double] = None,
+    var findSynonymsTime: Option[Double] = None)

--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -209,13 +209,11 @@ object MLParams {
  * @param testTime  (MLlib) Test time (for prediction on test set, or on training set if there
  *                  is no test set).
  * @param testMetric  (MLlib) Test metric, such as accuracy
-  * @param runAssociationRulesTime  (MLlib) run association rules time
-  * @param findSynonymsTime  (MLlib) word2Vec model find synonyms time
+ * @param additionalTests  (MLlib) Additional methods test results.
  */
 case class MLResult(
     trainingTime: Option[Double] = None,
     trainingMetric: Option[Double] = None,
     testTime: Option[Double] = None,
     testMetric: Option[Double] = None,
-    var runAssociationRulesTime: Option[Double] = None,
-    var findSynonymsTime: Option[Double] = None)
+    additionalTests: Map[String, Double])

--- a/src/main/scala/configs/mllib-small.yaml
+++ b/src/main/scala/configs/mllib-small.yaml
@@ -120,6 +120,7 @@ benchmarks:
       numExamples: 100
       vocabSize: 100
       docLength: 10
+      numSynonymsToFind: 3
   - name: recommendation.ALS
     params:
       numExamples: 100


### PR DESCRIPTION
Add additional method test for some ML algos.

In this PR, I add `associationRules` in `FPGrowth` and `findSynonyms`. 
After the design is accepted, I will add other methods later.

Add an interface in `BenchmarkableAlgorithm`:
```
  def testAdditionalMethods(ctx: MLBenchContext, model: Transformer): Map[String, () => _]
```
