### PR TITLE
[ML-3749] Log metric name and isLargerBetter in BenchmarkResult

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
@@ -7,6 +7,8 @@ import org.apache.spark.ml.evaluation.Evaluator
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 
+import com.databricks.spark.sql.perf._
+
 /**
  * The description of a benchmark for an ML algorithm. It follows a simple, standard proceduce:
  *  - generate some test and training data
@@ -38,7 +40,7 @@ trait BenchmarkAlgorithm extends Logging {
   def score(
       ctx: MLBenchContext,
       testSet: DataFrame,
-      model: Transformer): Double = -1.0 // Not putting NaN because it is not valid JSON.
+      model: Transformer): MLMetrics = new MLMetrics()
 
   def name: String = {
     this.getClass.getCanonicalName.replace("$", "")
@@ -67,9 +69,10 @@ trait ScoringWithEvaluator {
   final override def score(
       ctx: MLBenchContext,
       testSet: DataFrame,
-      model: Transformer): Double = {
+      model: Transformer): MLMetrics = {
     val eval = model.transform(testSet)
-    evaluator(ctx).evaluate(eval)
+    // TODO: add MetricName for evaluators
+    new MLMetrics("", evaluator(ctx).evaluate(eval), evaluator(ctx).isLargerBetter)
   }
 }
 

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
@@ -72,15 +72,15 @@ class MLPipelineStageBenchmarkable(
       val (scoreTrainTime, scoreTraining) = measureTime {
         test.score(param, trainingData, model)
       }
-      val metricTrainTime = new MLMetrics("trainTime", scoreTrainTime.toMillis, false)
-      val metricTrain = new MLMetrics("trainMetrics"+scoreTraining.metricName,
+      val metricTrainingTime = MLMetric("training.time", scoreTrainTime.toMillis, false)
+      val metricTraining = MLMetric("training."+scoreTraining.metricName,
         scoreTraining.metricValue,
         scoreTraining.isLargerBetter)
       val (scoreTestTime, scoreTest) = measureTime {
         test.score(param, testData, model)
       }
-      val metricTestTime = new MLMetrics("trainTime", scoreTestTime.toMillis, false)
-      val metricTest = new MLMetrics("trainMetrics"+scoreTraining.metricName,
+      val metricTestTime = MLMetric("test.time", scoreTestTime.toMillis, false)
+      val metricTest = MLMetric("test."+scoreTraining.metricName,
         scoreTraining.metricValue,
         scoreTraining.isLargerBetter)
 
@@ -94,14 +94,14 @@ class MLPipelineStageBenchmarkable(
           tuple._1 -> additionalMethodTime.toMillis.toDouble
       }
 
-      val ml = Array(metricTrainTime, metricTrain, metricTestTime, metricTest)
+      val mlMetrics = Array(metricTrainingTime, metricTraining, metricTestTime, metricTest)
 
       BenchmarkResult(
         name = name,
         mode = executionMode.toString,
         parameters = params.toMap,
         executionTime = Some(trainingTime.toMillis),
-        mlResult = Some(ml))
+        mlResult = Some(mlMetrics))
     } catch {
       case e: Exception =>
         BenchmarkResult(

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
@@ -72,9 +72,17 @@ class MLPipelineStageBenchmarkable(
       val (scoreTrainTime, scoreTraining) = measureTime {
         test.score(param, trainingData, model)
       }
+      val metricTrainTime = new MLMetrics("trainTime", scoreTrainTime.toMillis, false)
+      val metricTrain = new MLMetrics("trainMetrics"+scoreTraining.metricName,
+        scoreTraining.metricValue,
+        scoreTraining.isLargerBetter)
       val (scoreTestTime, scoreTest) = measureTime {
         test.score(param, testData, model)
       }
+      val metricTestTime = new MLMetrics("trainTime", scoreTestTime.toMillis, false)
+      val metricTest = new MLMetrics("trainMetrics"+scoreTraining.metricName,
+        scoreTraining.metricValue,
+        scoreTraining.isLargerBetter)
 
       logger.info(s"$this doBenchmark: Trained model in ${trainingTime.toMillis / 1000.0}" +
         s" s, Scored training dataset in ${scoreTrainTime.toMillis / 1000.0} s," +
@@ -86,12 +94,7 @@ class MLPipelineStageBenchmarkable(
           tuple._1 -> additionalMethodTime.toMillis.toDouble
       }
 
-      val ml = MLResult(
-        trainingTime = Some(trainingTime.toMillis),
-        trainingMetric = Some(scoreTraining),
-        testTime = Some(scoreTestTime.toMillis),
-        testMetric = Some(scoreTest / testDataCount.get),
-        additionalTests = additionalTests)
+      val ml = Array(metricTrainTime, metricTrain, metricTestTime, metricTest)
 
       BenchmarkResult(
         name = name,

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/Word2Vec.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/Word2Vec.scala
@@ -9,7 +9,6 @@ import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, split}
 
-import com.databricks.spark.sql.perf.MLResult
 import com.databricks.spark.sql.perf.mllib.{BenchmarkAlgorithm, MLBenchContext, TestFromTraining}
 import com.databricks.spark.sql.perf.mllib.OptionImplicits._
 import com.databricks.spark.sql.perf.mllib.data.DataGenerator

--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -83,7 +83,7 @@ case class BenchmarkResult(
     breakDown: Seq[BreakdownResult] = Nil,
     queryExecution: Option[String] = None,
     failure: Option[Failure] = None,
-    mlResult: Option[MLResult] = None)
+    mlResult: Option[Array[MLMetrics]] = None)
 
 /**
  * The execution time of a subtree of the query plan tree of a specific query.
@@ -223,19 +223,13 @@ object MLParams {
 }
 
 /**
- * Result information specific to MLlib.
+ * Metrics specific to MLlib benchmark.
  *
- * @param trainingTime  (MLlib) Training time.
- *                      executionTime is set to the same value to match Spark Core tests.
- * @param trainingMetric  (MLlib) Training metric, such as accuracy
- * @param testTime  (MLlib) Test time (for prediction on test set, or on training set if there
- *                  is no test set).
- * @param testMetric  (MLlib) Test metric, such as accuracy
- * @param additionalTests  (MLlib) Additional methods test results.
+ * @param metricName the name of the metric
+ * @param metricValue the value of the metric
+ * @param isLargerBetter  (MLlib) Test metric, such as accuracy
  */
-case class MLResult(
-    trainingTime: Option[Double] = None,
-    trainingMetric: Option[Double] = None,
-    testTime: Option[Double] = None,
-    testMetric: Option[Double] = None,
-    additionalTests: Map[String, Double])
+case class MLMetrics(
+    metricName: String = null,
+    metricValue: Double = 0.0,
+    isLargerBetter: Boolean = false)

--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -83,7 +83,7 @@ case class BenchmarkResult(
     breakDown: Seq[BreakdownResult] = Nil,
     queryExecution: Option[String] = None,
     failure: Option[Failure] = None,
-    mlResult: Option[Array[MLMetrics]] = None)
+    mlResult: Option[Array[MLMetric]] = None)
 
 /**
  * The execution time of a subtree of the query plan tree of a specific query.
@@ -227,9 +227,13 @@ object MLParams {
  *
  * @param metricName the name of the metric
  * @param metricValue the value of the metric
- * @param isLargerBetter  (MLlib) Test metric, such as accuracy
+ * @param isLargerBetter the indicator showing whether larger metric value is better
  */
-case class MLMetrics(
-    metricName: String = null,
-    metricValue: Double = 0.0,
-    isLargerBetter: Boolean = false)
+case class MLMetric(
+    metricName: String,
+    metricValue: Double,
+    isLargerBetter: Boolean)
+
+object MLMetric {
+  val Invalid = MLMetric("Invalid", 0.0, false)
+}


### PR DESCRIPTION

- Add new case class "MLMetrics" to save all different metrics

- Change "mlResult" in BenchmarkResult to Array[MLMetrics] 

- score function will return MLMetrics