### PR TITLE
[ML-3581] Add benchmarks to mllib-large.yaml for regression

### DIFF
--- a/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
+++ b/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
@@ -68,3 +68,26 @@ benchmarks:
       regParam: 0.01
       rank: 10
       maxIter: 10
+  - name: regression.DecisionTreeRegression
+    params:
+      depth: [5, 10]
+      numClasses: 4
+  - name: regression.GLMRegression
+    params:
+      numExamples: 500000
+      numTestExamples: 500000
+      numFeatures: 1000
+      link: log
+      family: gaussian
+      tol: 1e-6
+      maxIter: 10
+      regParam: 0.1
+  - name: regression.LinearRegression
+    params:
+      regParam: 0.01
+      tol: 0.0
+      maxIter: 20
+  - name: regression.RandomForestRegression
+    params:
+      depth: 10
+      maxIter: 4

--- a/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
+++ b/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
@@ -71,7 +71,6 @@ benchmarks:
   - name: regression.DecisionTreeRegression
     params:
       depth: [5, 10]
-      numClasses: 4
   - name: regression.GLMRegression
     params:
       numExamples: 500000
@@ -79,7 +78,7 @@ benchmarks:
       numFeatures: 1000
       link: log
       family: gaussian
-      tol: 1e-6
+      tol: 0.0
       maxIter: 10
       regParam: 0.1
   - name: regression.LinearRegression


### PR DESCRIPTION
Benchmark for regression is added to mllib-large.yaml.
DecisionTreeRegression, GLMRegression, LinearRegression, and RandomForestRegression are added. 

GBT, AFTSurvivalRegression, and IsotonicRegression are missing in spark-sql-perf. 