### PR TITLE
[ML-3824] Add benchmarks to mllib-large.yaml for FPGrowth

### DIFF
--- a/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
+++ b/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
@@ -59,6 +59,10 @@ benchmarks:
       optimizer:
         - em
         - online
+  - name: fpm.FPGrowth
+    params:
+      numItems: 10000
+      itemSetSize: 10
   - name: recommendation.ALS
     params:
       numExamples: 50000000

--- a/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
+++ b/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
@@ -62,7 +62,7 @@ benchmarks:
   - name: fpm.FPGrowth
     params:
       numItems: 10000
-      itemSetSize: 10
+      itemSetSize: [4, 10]
   - name: recommendation.ALS
     params:
       numExamples: 50000000


### PR DESCRIPTION
Benchmark for FPGrowth is added to mllib-large.yaml.