### PR TITLE
[ML-3583] Add benchmarks to mllib-large.yaml for featurization

### DIFF
--- a/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
+++ b/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
@@ -94,7 +94,7 @@ benchmarks:
       numExamples: 10000
       vocabSize: 100
       docLength: 1000
-      numSynonymsToFind:
+      numSynonymsToFind: 3
   - name: recommendation.ALS
     params:
       numExamples: 50000000

--- a/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
+++ b/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
@@ -59,6 +59,42 @@ benchmarks:
       optimizer:
         - em
         - online
+  - name: feature.BucketedRandomProjectionLSH
+    params:
+      numHashTables: 20
+  - name: feature.Bucketizer
+    params:
+      bucketizerNumBuckets: 20
+  - name: feature.HashingTF
+    params:
+      docLength: 2000
+      vocabSize: 200
+  - name: feature.MinHashLSH
+    params:
+      numFeatures: 10000
+      numHashTables: 10
+  - name: feature.OneHotEncoder
+    params:
+      featureArity: 10000
+  - name: feature.StringIndexer
+    params:
+      vocabSize: 10000
+  - name: feature.Tokenizer
+    params:
+      vocabSize: 2000
+      docLength: 10000
+  - name: feature.VectorAssembler
+    params:
+      numInputCols: 100
+  - name: feature.VectorSlicer
+    params:
+      numFeatures: 5000
+  - name: feature.Word2Vec
+    params:
+      numExamples: 10000
+      vocabSize: 100
+      docLength: 1000
+      numSynonymsToFind:
   - name: recommendation.ALS
     params:
       numExamples: 50000000

--- a/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
+++ b/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
@@ -85,7 +85,7 @@ benchmarks:
       docLength: 10000
   - name: feature.VectorAssembler
     params:
-      numInputCols: 100
+      numInputCols: 20
   - name: feature.VectorSlicer
     params:
       numFeatures: 5000


### PR DESCRIPTION
Benchmark for featurization is added to mllib-large.yaml. 
Cannot run QuantileDiscretizer with spark 2.3. Leave this as future work:
https://databricks.atlassian.net/browse/ML-3869