### PR TITLE
[ML-3869] Make Quantilediscretizer work with spark-2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ sparkPackageName := "databricks/spark-sql-perf"
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
-sparkVersion := "2.3.0"
+sparkVersion := "2.2.0"
 
 sparkComponents ++= Seq("sql", "hive", "mllib")
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ sparkPackageName := "databricks/spark-sql-perf"
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
-sparkVersion := "2.2.0"
+sparkVersion := "2.3.0"
 
 sparkComponents ++= Seq("sql", "hive", "mllib")
 

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/QuantileDiscretizer.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/QuantileDiscretizer.scala
@@ -31,6 +31,7 @@ object QuantileDiscretizer extends BenchmarkAlgorithm with TestFromTraining with
     import ctx.params._
     new ml.feature.QuantileDiscretizer()
       .setInputCol(inputCol)
+      .setOutputCol(outputCol)
       .setNumBuckets(bucketizerNumBuckets)
       .setRelativeError(relativeError)
   }

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/UnaryTransformer.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/feature/UnaryTransformer.scala
@@ -3,4 +3,5 @@ package com.databricks.spark.sql.perf.mllib.feature
 /** Trait defining common state/methods for featurizers taking a single input col */
 private[feature] trait UnaryTransformer {
   private[feature] val inputCol = "inputCol"
+  private[feature] val outputCol = "outputCol"
 }


### PR DESCRIPTION
Add setOutputCol for Quantilediscretizer so that it works for  spark-2.3.

The code has been manually tested by change the spark version.