### PR TITLE
[ML-3870] Make spark-sql-perf master compiled with spark 2.3 and scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: scala
+scala:
+  - 2.11.8
 sudo: false
 jdk:
   oraclejdk8

--- a/bin/spark-perf
+++ b/bin/spark-perf
@@ -5,5 +5,5 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VERSION=`git -C $DIR/../ tag | tail -n 1 | cut -c 2-`
-ARGS="sparkPackage com.databricks:spark-sql-perf_2.10:$VERSION com.databricks.spark.sql.perf.RunBenchmark $@"
+ARGS="sparkPackage com.databricks:spark-sql-perf_2.11:$VERSION com.databricks.spark.sql.perf.RunBenchmark $@"
 build/sbt "$ARGS"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "com.databricks"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8")
+crossScalaVersions := Seq("2.11.8")
 
 sparkPackageName := "databricks/spark-sql-perf"
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ sparkPackageName := "databricks/spark-sql-perf"
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
-sparkVersion := "2.2.0"
+sparkVersion := "2.3.0"
 
 sparkComponents ++= Seq("sql", "hive", "mllib")
 


### PR DESCRIPTION
Change the build config to update spark 2.3 and update the scala dependence in bin/spark-perf