### PR TITLE
Update Scala Logging to officially supported one

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 
 libraryDependencies += "org.yaml" % "snakeyaml" % "1.17"
 
-libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
+libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
 
 fork := true
 

--- a/src/main/scala/com/databricks/spark/sql/perf/Benchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Benchmarkable.scala
@@ -18,7 +18,7 @@ package com.databricks.spark.sql.perf
 
 import java.util.UUID
 
-import com.typesafe.scalalogging.slf4j.{LazyLogging => Logging}
+import com.typesafe.scalalogging.{LazyLogging => Logging}
 
 import scala.concurrent.duration._
 import scala.collection.mutable.ArrayBuffer

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
@@ -1,6 +1,6 @@
 package com.databricks.spark.sql.perf.mllib
 
-import com.typesafe.scalalogging.slf4j.{LazyLogging => Logging}
+import com.typesafe.scalalogging.{LazyLogging => Logging}
 import org.apache.spark.ml.attribute.{NominalAttribute, NumericAttribute}
 import org.apache.spark.ml.{Estimator, PipelineStage, Transformer}
 import org.apache.spark.ml.evaluation.Evaluator

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLLib.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLLib.scala
@@ -4,7 +4,7 @@ package com.databricks.spark.sql.perf.mllib
 import scala.io.Source
 import scala.language.implicitConversions
 
-import com.typesafe.scalalogging.slf4j.{LazyLogging => Logging}
+import com.typesafe.scalalogging.{LazyLogging => Logging}
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.{SparkConf, SparkContext}

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
@@ -2,7 +2,7 @@ package com.databricks.spark.sql.perf.mllib
 
 import scala.collection.mutable.ArrayBuffer
 
-import com.typesafe.scalalogging.slf4j.{LazyLogging => Logging}
+import com.typesafe.scalalogging.{LazyLogging => Logging}
 
 import org.apache.spark.ml.{Estimator, Transformer}
 import org.apache.spark.sql._


### PR DESCRIPTION
### Description

Scala logging slf4j (https://mvnrepository.com/artifact/com.typesafe.scala-logging/scala-logging-slf4j) is no longer supported (since 2014). I have also started receiving conflicts between packages since this one is using legacy one.

Update to maintained solves the issue https://mvnrepository.com/artifact/com.typesafe.scala-logging/scala-logging

### How did I test?

I run TPCDS benchmark with Spark both on YARN/HDFS and Kubernetes/S3.

CC: @prasanthkothuri
