### PR TITLE
[ML-2918] Call count() in default score() to improve timing of transform()

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
@@ -35,12 +35,17 @@ trait BenchmarkAlgorithm extends Logging {
   /**
    * The unnormalized score of the training procedure on a dataset. The normalization is
    * performed by the caller.
+   * This calls `count()` on the transformed data to attempt to materialize the result for
+   * recording timing metrics.
    */
   @throws[Exception]("if scoring fails")
   def score(
       ctx: MLBenchContext,
       testSet: DataFrame,
-      model: Transformer): MLMetric = MLMetric.Invalid
+      model: Transformer): MLMetric = {
+    model.transform(testSet).count()
+    MLMetric.Invalid
+  }
 
   def name: String = {
     this.getClass.getCanonicalName.replace("$", "")

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/BenchmarkAlgorithm.scala
@@ -43,7 +43,11 @@ trait BenchmarkAlgorithm extends Logging {
       ctx: MLBenchContext,
       testSet: DataFrame,
       model: Transformer): MLMetric = {
-    model.transform(testSet).count()
+    val output = model.transform(testSet)
+    // We create a useless UDF to make sure the entire DataFrame is instantiated.
+    val fakeUDF = udf { (_: Any) => 0 }
+    val columns = testSet.columns
+    output.select(sum(fakeUDF(struct(columns.map(col) : _*)))).first()
     MLMetric.Invalid
   }
 


### PR DESCRIPTION
For Models and Transformers which are not tested with Evaluators, I think we are not timing transform() correctly here: https://github.com/databricks/spark-sql-perf/blob/aa1587fec5a08eeca78a06389599939d8dced0bf/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala#L65

Since transform() is lazy, we need to materialize it during timing.  This PR currently just calls count() in the default implementation of score().