### PR TITLE
Increase mllib-large test timeout to 12 hours

### DIFF
--- a/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
+++ b/src/main/resources/com/databricks/spark/sql/perf/mllib/config/mllib-large.yaml
@@ -1,5 +1,5 @@
 output: /databricks/spark/sql/mllib-perf-ci
-timeoutSeconds: 1000 # This limit is for all benchmarks and should be bumped as more are added.
+timeoutSeconds: 43200 # This limit is for all benchmarks and should be bumped as more are added.
 common:
   numExamples: 1000000
   numTestExamples: 1000000


### PR DESCRIPTION
We set timeout to 1000 seconds. This is not long enough given the tests we added. This PR change it to 12 hours. It leaves some space for future tests. We just need this timeout incase some tests hang.