### PR TITLE
[ML-4154] Added testing for before/after of ml benchmarks.

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
@@ -27,7 +27,7 @@ class MLPipelineStageBenchmarkable(
 
   override protected val executionMode: ExecutionMode = ExecutionMode.SparkPerfResults
 
-  override protected def beforeBenchmark(): Unit = {
+  override protected[mllib] def beforeBenchmark(): Unit = {
     logger.info(s"$this beforeBenchmark")
     try {
       testData = test.testDataSet(param)
@@ -43,7 +43,7 @@ class MLPipelineStageBenchmarkable(
     }
   }
 
-  override protected def afterBenchmark(sc: SparkContext): Unit = {
+  override protected[mllib] def afterBenchmark(sc: SparkContext): Unit = {
     // Best-effort clean up of weakly referenced RDDs, shuffles, and broadcasts
     // Remove any leftover blocks that still exist
     sc.getExecutorStorageStatus

--- a/src/test/scala/com/databricks/spark/sql/perf/mllib/MLLibSuite.scala
+++ b/src/test/scala/com/databricks/spark/sql/perf/mllib/MLLibSuite.scala
@@ -1,10 +1,29 @@
 package com.databricks.spark.sql.perf.mllib
 
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.Row
 
-class MLLibTest extends FunSuite {
+class MLLibSuite extends FunSuite with BeforeAndAfterAll {
+
+  private var sc: SparkContext = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val sparkConf = new SparkConf().setAppName("MLlib QA").setMaster("local[2]")
+    sc = SparkContext.getOrCreate(sparkConf)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    if (sc != null) {
+      sc.stop()
+    }
+    // To avoid RPC rebinding to the same port, since it doesn't unbind immediately on shutdown
+    System.clearProperty("spark.driver.port")
+    sc = null
+  }
 
   test("test MlLib benchmarks with mllib-small.yaml.") {
     val results = MLLib.run(yamlConfig = MLLib.smallConfig)
@@ -18,6 +37,14 @@ class MLLibTest extends FunSuite {
              """.stripMargin)
       }
       fail("Unable to run all benchmarks successfully, see console output for more info.")
+    }
+  }
+
+  test("test before & after benchmark methods for pipeline benchmarks.") {
+    val benchmarks = MLLib.getBenchmarks(MLLib.getConf(yamlConfig = MLLib.smallConfig))
+    benchmarks.foreach { b =>
+      b.beforeBenchmark()
+      b.afterBenchmark(sc)
     }
   }
 }


### PR DESCRIPTION
This PR adds a unit tests which runs the `beforeBenchmark` & `afterBenchmark` methods for the benchmarks included in mllib-small.yaml.