### PR TITLE
Make TPCDS queryNames public so it can be accessed from notebooks.

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/tpcds/TPCDS_2_4_Queries.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpcds/TPCDS_2_4_Queries.scala
@@ -27,7 +27,7 @@ trait Tpcds_2_4_Queries extends Benchmark {
 
   import ExecutionMode._
 
-  private val queryNames = Seq(
+  val queryNames = Seq(
     "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10",
     "q11", "q12", "q13", "q14a", "q14b", "q15", "q16", "q17", "q18", "q19",
     "q20", "q21", "q22", "q23a", "q23b", "q24a", "q24b", "q25", "q26", "q27",


### PR DESCRIPTION
Just a small change so that `queryNames` val from `com/databricks/spark/sql/perf/tpcds/TPCDS_2_4_Queries.scala` is accessible from notebooks and get the internal query naming to select individual queries.