### PR TITLE
Fixing TPCH DDL datatype of customer.c_nationkey to long

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/tpch/TPCH.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpch/TPCH.scala
@@ -111,7 +111,7 @@ class TPCHTables(
       'c_custkey.long,
       'c_name.string,
       'c_address.string,
-      'c_nationkey.string,
+      'c_nationkey.long,
       'c_phone.string,
       'c_acctbal.decimal(12, 2),
       'c_mktsegment.string,


### PR DESCRIPTION
Fixing TPCH DDL datatype of `customer.c_nationkey` from `string` to `long` as from the spec.  Tables should be regenerated to make use of the changes.