### PR TITLE
Bumping version to 0.5.1-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"
+version in ThisBuild := "0.5.1-SNAPSHOT"


### PR DESCRIPTION
Due to latest merged PRs involving updating libraries and other small fixes, I'll propose to bump the version in the code and tag the release up if no objections. Relevant PRs:
[Update Scala Logging to officially supported one](https://github.com/databricks/spark-sql-perf/commit/56f73482d7e1d1ba4651d55ef1531c03e352d1b0)
[Fix compile for Spark 2.4 SNAPSHOT and only catch NonFatal](https://github.com/databricks/spark-sql-perf/commit/bb12958874b844bc3356c26f1e570ea3ff08a93b)