### PR TITLE
Fix prewarming query planning unintentionally

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/BenchmarkableListener.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/BenchmarkableListener.scala
@@ -1,0 +1,10 @@
+package com.databricks.spark.sql.perf
+
+import org.apache.spark.sql.execution.SparkPlan
+
+private[perf] trait BenchmarkableListener {
+
+  /** Called after a query in a [[Benchmarkable]] is planned **/
+  def onQueryPlanned(plan: SparkPlan): Unit = {
+  }
+}

--- a/src/main/scala/com/databricks/spark/sql/perf/Query.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/Query.scala
@@ -62,7 +62,8 @@ class Query(
   protected override def doBenchmark(
       includeBreakdown: Boolean,
       description: String = "",
-      messages: ArrayBuffer[String]): BenchmarkResult = {
+      messages: ArrayBuffer[String],
+      listener: Option[BenchmarkableListener]): BenchmarkResult = {
     try {
       val dataFrame = buildDataFrame
       val queryExecution = dataFrame.queryExecution
@@ -79,6 +80,8 @@ class Query(
       val planningTime = measureTimeMs {
         queryExecution.executedPlan
       }
+
+      listener.foreach(_.onQueryPlanned(queryExecution.executedPlan))
 
       val breakdownResults = if (includeBreakdown) {
         val depth = queryExecution.executedPlan.collect { case p: SparkPlan => p }.size

--- a/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/mllib/MLPipelineStageBenchmarkable.scala
@@ -45,7 +45,8 @@ class MLPipelineStageBenchmarkable(
   override protected def doBenchmark(
     includeBreakdown: Boolean,
     description: String,
-    messages: ArrayBuffer[String]): BenchmarkResult = {
+    messages: ArrayBuffer[String],
+    listener: Option[BenchmarkableListener]): BenchmarkResult = {
     try {
       val (trainingTime, model: Transformer) = measureTime {
         logger.info(s"$this: train: trainingSet=${trainingData.schema}")

--- a/src/main/scala/com/databricks/spark/sql/perf/results.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/results.scala
@@ -26,13 +26,15 @@ import com.databricks.spark.sql.perf.mllib.ReflectionUtils
  * @param tags Tags of this iteration (variations are stored at here).
  * @param configuration Configuration properties of this iteration.
  * @param results The performance results of queries for this iteration.
+ * @param prewarmQueryPlanning Whether prewarm query planning was enabled.
  */
 case class ExperimentRun(
     timestamp: Long,
     iteration: Int,
     tags: Map[String, String],
     configuration: BenchmarkConfiguration,
-    results: Seq[BenchmarkResult])
+    results: Seq[BenchmarkResult],
+    prewarmQueryPlanning: Boolean = false)
 
 /**
  * The configuration used for an iteration of an experiment.


### PR DESCRIPTION
Before this change, logic in ExperimentStatus would cause
query planning to be prewarmed as a side effect of capturing
the current plan. This change removes this side effect, but
adds an option to restore the previous behavior if desired
by the user.