### PR TITLE
Fix the CI cannot install Oracle JDK 8 issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.8
+  - 2.12.10
 sudo: false
 jdk:
   openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: scala
 scala:
   - 2.12.10
 sudo: false
+dist: trusty
 jdk:
-  openjdk8
+  oraclejdk8
 cache:
   directories:
     - $HOME/.ivy2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
   - 2.11.8
 sudo: false
 jdk:
-  oraclejdk8
+  openjdk8
 cache:
   directories:
     - $HOME/.ivy2

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "com.databricks"
 
 scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.12.10", "2.11.12")
+crossScalaVersions := Seq("2.12.10")
 
 sparkPackageName := "databricks/spark-sql-perf"
 


### PR DESCRIPTION
Fix the CI cannot install Oracle JDK 8 issue:
```
Installing oraclejdk8
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2020-06-02
Expected feature release number in range of 9 to 17, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```