### PR TITLE
Fix output from dbgen

### DIFF
--- a/src/main/scala/com/databricks/spark/sql/perf/tpch/TPCH.scala
+++ b/src/main/scala/com/databricks/spark/sql/perf/tpch/TPCH.scala
@@ -50,9 +50,10 @@ class DBGEN(dbgenDir: String, params: Seq[String]) extends DataGenerator {
           "partsupp" -> "S"
         )
         val paramsString = params.mkString(" ")
+        var tableFile = if (smallTables.contains(name)) s"$name.tbl" else s"$name.tbl.$i"
         val commands = Seq(
           "bash", "-c",
-          s"cd $localToolsDir && ./dbgen -q $paramsString -T ${shortTableNames(name)} -s $scaleFactor $parallel")
+          s"cd $localToolsDir && ./dbgen -q $paramsString -T ${shortTableNames(name)} -s $scaleFactor $parallel && cat $tableFile && rm $tableFile")
         println(commands)
         BlockingLineStream(commands)
       }.repartition(numPartitions)


### PR DESCRIPTION
TPC-H related data could not be generated because dbgen writes to a file and not to stdout, as opposed to dsdgen.
This patch dumps each table content and removes the generated file.
Removing generated files is necessary, otherwise data generation hangs if the table already exists.
