### PR TITLE
Update Spark repository for sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // You may use this file to add plugin dependencies for sbt.
 
-resolvers += "Spark Packages repo" at "https://dl.bintray.com/spark-packages/maven/"
+resolvers += "Spark Packages repo" at "https://repos.spark-packages.org/"
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 


### PR DESCRIPTION
https://dl.bintray.com/spark-packages/maven is a dead link now. According to https://github.com/databricks/sbt-spark-package/issues/50, this is the new link: https://repos.spark-packages.org