### PR TITLE
Removing unnecessary joins

### DIFF
--- a/src/main/resources/tpcds_2_4/q72.sql
+++ b/src/main/resources/tpcds_2_4/q72.sql
@@ -16,7 +16,6 @@
  join date_dim d2 on (inv_date_sk = d2.d_date_sk)
  join date_dim d3 on (cs_ship_date_sk = d3.d_date_sk)
  left outer join promotion on (cs_promo_sk=p_promo_sk)
- left outer join catalog_returns on (cr_item_sk = cs_item_sk and cr_order_number = cs_order_number)
  where d1.d_week_seq = d2.d_week_seq
    and inv_quantity_on_hand < cs_quantity
    and d3.d_date > (cast(d1.d_date AS DATE) + interval '5' day)


### PR DESCRIPTION
None of the columns used in select part or filtering are from catalog_returns. Also having a left join has no impact on resultset.