### PR TITLE
download sbt-launch-lib from github instead of dl.binary

### DIFF
--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -45,9 +45,8 @@ dlog () {
 
 acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\.version/ {print $2}' ./project/build.properties`
-  URL1=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
+  URL1=https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.zip
   JAR=build/sbt-launch-${SBT_VERSION}.jar
-
   sbt_jar=$JAR
 
   if [[ ! -f "$sbt_jar" ]]; then
@@ -55,13 +54,15 @@ acquire_sbt_jar () {
     if [ ! -f "${JAR}" ]; then
     # Download
     printf "Attempting to fetch sbt\n"
-    JAR_DL="${JAR}.part"
+    COMPLETE_SBT="build/sbt.zip"
     if [ $(command -v curl) ]; then
-      curl --fail --location --silent ${URL1} > "${JAR_DL}" &&\
-        mv "${JAR_DL}" "${JAR}"
+      curl --fail --location --silent ${URL1} > "${COMPLETE_SBT}" &&\
+        unzip ${COMPLETE_SBT} &&\
+        cp "sbt/bin/sbt-launch.jar" "${JAR}"
     elif [ $(command -v wget) ]; then
-      wget --quiet ${URL1} -O "${JAR_DL}" &&\
-        mv "${JAR_DL}" "${JAR}"
+      wget --quiet ${URL1} -O "${COMPLETE_SBT}" &&\
+        unzip ${COMPLETE_SBT} &&\
+        cp "sbt/bin/sbt-launch.jar" "${JAR}"
     else
       printf "You do not have curl or wget installed, please install sbt manually from http://www.scala-sbt.org/\n"
       exit -1


### PR DESCRIPTION
https://dl.bintray.com/ site has down since two months ago, so every time we run the script the fetch for the sbt-launcher-lib from this site will return 502 and then fail.This pr fix this by download sbt-launcher-lib jar from github